### PR TITLE
Fix namespace issue

### DIFF
--- a/kvision-modules/kvision-chart/src/main/kotlin/pl/treksoft/kvision/chart/Configuration.kt
+++ b/kvision-modules/kvision-chart/src/main/kotlin/pl/treksoft/kvision/chart/Configuration.kt
@@ -728,7 +728,7 @@ fun ChartScales.toJs(i18nTranslator: (String) -> (String)): dynamic {
 /**
  * Chart options.
  */
-data class Options(
+data class ChartOptions(
     val responsive: Boolean = true,
     val responsiveAnimationDuration: Int = 0,
     val aspectRatio: Int = 2,

--- a/kvision-modules/kvision-chart/src/main/kotlin/pl/treksoft/kvision/chart/Configuration.kt
+++ b/kvision-modules/kvision-chart/src/main/kotlin/pl/treksoft/kvision/chart/Configuration.kt
@@ -758,7 +758,7 @@ data class ChartOptions(
  * An extension function to convert configuration class to JS object.
  */
 @Suppress("ComplexMethod")
-fun Options.toJs(i18nTranslator: (String) -> (String)): dynamic {
+fun ChartOptions.toJs(i18nTranslator: (String) -> (String)): dynamic {
     return obj {
         this.responsive = responsive
         this.responsiveAnimationDuration = responsiveAnimationDuration
@@ -889,7 +889,7 @@ data class Configuration(
     val type: ChartType,
     val dataSets: List<DataSets>,
     val labels: List<String>? = null,
-    val options: Options? = null
+    val options: ChartOptions? = null
 )
 
 /**

--- a/kvision-modules/kvision-chart/src/test/kotlin/test/pl/treksoft/kvision/chart/ChartCanvasSpec.kt
+++ b/kvision-modules/kvision-chart/src/test/kotlin/test/pl/treksoft/kvision/chart/ChartCanvasSpec.kt
@@ -25,7 +25,7 @@ import pl.treksoft.kvision.chart.ChartCanvas
 import pl.treksoft.kvision.chart.ChartType
 import pl.treksoft.kvision.chart.Configuration
 import pl.treksoft.kvision.chart.DataSets
-import pl.treksoft.kvision.chart.Options
+import pl.treksoft.kvision.chart.ChartOptions
 import pl.treksoft.kvision.panel.Root
 import test.pl.treksoft.kvision.DomSpec
 import kotlin.browser.document
@@ -62,7 +62,7 @@ class ChartCanvasSpec : DomSpec {
                 configuration = Configuration(
                     ChartType.SCATTER,
                     listOf(DataSets(label = "Chart", data = listOf(0, 1))),
-                    options = Options(responsive = false)
+                    options = ChartOptions(responsive = false)
                 )
             )
             root.add(chart)

--- a/kvision-modules/kvision-chart/src/test/kotlin/test/pl/treksoft/kvision/chart/ChartSpec.kt
+++ b/kvision-modules/kvision-chart/src/test/kotlin/test/pl/treksoft/kvision/chart/ChartSpec.kt
@@ -25,7 +25,7 @@ import pl.treksoft.kvision.chart.Chart
 import pl.treksoft.kvision.chart.ChartType
 import pl.treksoft.kvision.chart.Configuration
 import pl.treksoft.kvision.chart.DataSets
-import pl.treksoft.kvision.chart.Options
+import pl.treksoft.kvision.chart.ChartOptions
 import pl.treksoft.kvision.panel.Root
 import pl.treksoft.kvision.utils.px
 import test.pl.treksoft.kvision.DomSpec
@@ -65,7 +65,7 @@ class ChartSpec : DomSpec {
                 Configuration(
                     ChartType.SCATTER,
                     listOf(DataSets(label = "Chart", data = listOf(0, 1))),
-                    options = Options(responsive = false)
+                    options = ChartOptions(responsive = false)
                 ), 300, 600
             )
             root.add(chart)

--- a/kvision-modules/kvision-tabulator/src/main/kotlin/pl/treksoft/kvision/tabulator/Options.kt
+++ b/kvision-modules/kvision-tabulator/src/main/kotlin/pl/treksoft/kvision/tabulator/Options.kt
@@ -411,7 +411,7 @@ fun ColumnDefinition.toJs(i18nTranslator: (String) -> (String)): Tabulator.Colum
 /**
  * Tabulator options.
  */
-data class Options(
+data class TabulatorOptions(
     val height: String? = null,
     val virtualDom: Boolean? = null,
     val virtualDomBuffer: Int? = null,

--- a/kvision-modules/kvision-tabulator/src/main/kotlin/pl/treksoft/kvision/tabulator/Options.kt
+++ b/kvision-modules/kvision-tabulator/src/main/kotlin/pl/treksoft/kvision/tabulator/Options.kt
@@ -572,7 +572,7 @@ data class TabulatorOptions(
  * An extension function to convert tabulator options class to JS object.
  */
 @Suppress("UNCHECKED_CAST_TO_EXTERNAL_INTERFACE", "ComplexMethod")
-fun Options.toJs(i18nTranslator: (String) -> (String)): Tabulator.Options {
+fun TabulatorOptions.toJs(i18nTranslator: (String) -> (String)): Tabulator.Options {
     return obj {
         if (height != null) this.height = height
         if (virtualDom != null) this.virtualDom = virtualDom

--- a/kvision-modules/kvision-tabulator/src/main/kotlin/pl/treksoft/kvision/tabulator/Tabulator.kt
+++ b/kvision-modules/kvision-tabulator/src/main/kotlin/pl/treksoft/kvision/tabulator/Tabulator.kt
@@ -54,7 +54,7 @@ import pl.treksoft.kvision.tabulator.js.Tabulator as JsTabulator
 @Suppress("LargeClass", "TooManyFunctions")
 open class Tabulator<T : Any>(
     protected val data: List<T>? = null,
-    val options: Options = Options(),
+    val options: TabulatorOptions = TabulatorOptions(),
     types: Set<TableType> = setOf(),
     classes: Set<String> = setOf(),
     protected val dataSerializer: KSerializer<T>? = null
@@ -561,7 +561,7 @@ open class Tabulator<T : Any>(
          */
         inline fun <reified T : Any> Container.tabulator(
             data: List<T>? = null,
-            options: Options = Options(),
+            options: TabulatorOptions = TabulatorOptions(),
             types: Set<TableType> = setOf(),
             classes: Set<String> = setOf(),
             noinline init: (Tabulator<T>.() -> Unit)? = null
@@ -578,7 +578,7 @@ open class Tabulator<T : Any>(
         inline fun <reified T : Any, S : Any, A : RAction> Container.tabulator(
             store: ReduxStore<S, A>,
             noinline dataFactory: (S) -> List<T>,
-            options: Options = Options(),
+            options: TabulatorOptions = TabulatorOptions(),
             types: Set<TableType> = setOf(),
             classes: Set<String> = setOf(),
             noinline init: (Tabulator<T>.() -> Unit)? = null
@@ -594,7 +594,7 @@ open class Tabulator<T : Any>(
          */
         inline fun <reified T : Any, A : RAction> Container.tabulator(
             store: ReduxStore<List<T>, A>,
-            options: Options = Options(),
+            options: TabulatorOptions = TabulatorOptions(),
             types: Set<TableType> = setOf(),
             classes: Set<String> = setOf(),
             noinline init: (Tabulator<T>.() -> Unit)? = null
@@ -609,7 +609,7 @@ open class Tabulator<T : Any>(
          * DSL builder extension function for dynamic data (send within options parameter).
          */
         fun <T : Any> Container.tabulator(
-            options: Options = Options(),
+            options: TabulatorOptions = TabulatorOptions(),
             types: Set<TableType> = setOf(),
             classes: Set<String> = setOf(),
             init: (Tabulator<T>.() -> Unit)? = null
@@ -625,7 +625,7 @@ open class Tabulator<T : Any>(
          */
         @UseExperimental(ImplicitReflectionSerializer::class)
         inline fun <reified T : Any> create(
-            data: List<T>? = null, options: Options = Options(),
+            data: List<T>? = null, options: TabulatorOptions = TabulatorOptions(),
             types: Set<TableType> = setOf(),
             classes: Set<String> = setOf(),
             noinline init: (Tabulator<T>.() -> Unit)? = null
@@ -642,7 +642,7 @@ open class Tabulator<T : Any>(
         inline fun <reified T : Any, S : Any, A : RAction> create(
             store: ReduxStore<S, A>,
             noinline dataFactory: (S) -> List<T>,
-            options: Options = Options(),
+            options: TabulatorOptions = TabulatorOptions(),
             types: Set<TableType> = setOf(),
             classes: Set<String> = setOf(),
             noinline init: (Tabulator<T>.() -> Unit)? = null
@@ -662,7 +662,7 @@ open class Tabulator<T : Any>(
         @UseExperimental(ImplicitReflectionSerializer::class)
         inline fun <reified T : Any, A : RAction> create(
             store: ReduxStore<List<T>, A>,
-            options: Options = Options(),
+            options: TabulatorOptions = TabulatorOptions(),
             types: Set<TableType> = setOf(),
             classes: Set<String> = setOf(),
             noinline init: (Tabulator<T>.() -> Unit)? = null

--- a/kvision-modules/kvision-tabulator/src/test/kotlin/test/pl/treksoft/kvision/tabulator/TabulatorSpec.kt
+++ b/kvision-modules/kvision-tabulator/src/test/kotlin/test/pl/treksoft/kvision/tabulator/TabulatorSpec.kt
@@ -22,7 +22,7 @@
 package test.pl.treksoft.kvision.tabulator
 
 import pl.treksoft.kvision.panel.Root
-import pl.treksoft.kvision.tabulator.Options
+import pl.treksoft.kvision.tabulator.TabulatorOptions
 import pl.treksoft.kvision.tabulator.Tabulator
 import pl.treksoft.kvision.utils.obj
 import test.pl.treksoft.kvision.DomSpec
@@ -35,7 +35,7 @@ class TabulatorSpec : DomSpec {
     fun render() {
         run {
             val root = Root("test", true)
-            val tabulator = Tabulator<Any>(options = Options(data = arrayOf(obj {
+            val tabulator = Tabulator<Any>(options = TabulatorOptions(data = arrayOf(obj {
                 id = 1
                 name = "Name"
                 age = 40


### PR DESCRIPTION
Rename 2 conflicting Options variables in the Charts and Tabulator packages to ChartOptions and TabulatorOptions respectively