### PR TITLE
NPM Publishing through gradle

### DIFF
--- a/kvision-assets/build.gradle.kts
+++ b/kvision-assets/build.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+  id("lt.petuska.npm.publish") version "0.1.0"
+}
+
+npmPublishing {
+  publications {
+    publication(project.name) {
+      main = "index.js"
+      readme = file("README.md")
+      files {
+        from(projectDir) {
+          include("css/**", "img/**", "js/**", "index.js", "package.json")
+        }
+      }
+    }
+  }
+  
+  repositories {
+    repository("npmjs") {
+      registry = uri("https://registry.npmjs.org")
+      authToken = System.getenv("NPM_AUTH_TOKEN")
+    }
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,7 @@ pluginManagement {
         maven { url = uri("https://dl.bintray.com/kotlin/kotlin-eap") }
         maven { url = uri("https://kotlin.bintray.com/kotlinx") }
         maven { url = uri("https://dl.bintray.com/rjaros/kotlin") }
+        maven("https://dl.bintray.com/mpetuska/lt.petuska")
         mavenLocal()
     }
     resolutionStrategy {
@@ -61,5 +62,6 @@ include(
     "kvision-modules:kvision-server-micronaut",
     "kvision-modules:kvision-testutils",
     "kvision-tools:kvision-compiler-plugin",
-    "kvision-tools:kvision-gradle-plugin"
+    "kvision-tools:kvision-gradle-plugin",
+    "kvision-assets"
 )


### PR DESCRIPTION
Got way too excited and though I'll give it a go. Feel free to decline it if you prefer the direct npm way.

package.json is not yet managed by gradle (since some of the package.json fieldsyou're using are currently missing in the npm-publish plugin, gonna add them soon) and instead just copied as-is

Tested it on my own [registry](https://gitlab.com/lt.petuska/npm-publish/-/packages/585542), let me know when you want hat removed :)