### PR TITLE
Make hooks in `Widget` private to prevent conflicts

### DIFF
--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/OnsenUi.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/OnsenUi.kt
@@ -405,7 +405,7 @@ fun Widget.enableGestureDetector() {
     if (this.getElement() != null) {
         ons.GestureDetector(this.getElement())
     } else {
-        this.afterInsertHook = {
+        this.addAfterInsertHook {
             ons.GestureDetector(it.elm)
         }
     }

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/tabbar/Tab.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/tabbar/Tab.kt
@@ -121,7 +121,7 @@ open class Tab(
             if (content?.getElement() != null) {
                 done(content?.getElement())
             } else {
-                content?.afterInsertHook = {
+                content?.addAfterInsertHook {
                     @Suppress("UnsafeCastFromDynamic")
                     done(it.elm)
                 }

--- a/kvision-modules/kvision-react/src/main/kotlin/pl/treksoft/kvision/react/React.kt
+++ b/kvision-modules/kvision-react/src/main/kotlin/pl/treksoft/kvision/react/React.kt
@@ -120,10 +120,7 @@ fun <S> Container.reactBind(
     builder: RBuilder.(getState: () -> S, changeState: ((S) -> S) -> Unit) -> Unit
 ): React<S> {
     val react = React(state.getState(), classes ?: className.set, builder)
-    val unsubscribe = state.subscribe { react.state = it }
-    react.afterDisposeHook = {
-        unsubscribe()
-    }
+    react.addAfterDisposeHook(state.subscribe { react.state = it })
     this.add(react)
     return react
 }

--- a/kvision-modules/kvision-tabulator/src/main/kotlin/pl/treksoft/kvision/tabulator/Tabulator.kt
+++ b/kvision-modules/kvision-tabulator/src/main/kotlin/pl/treksoft/kvision/tabulator/Tabulator.kt
@@ -766,12 +766,9 @@ open class Tabulator<T : Any>(
             val data = dataFactory(store.getState())
             val tabulator = Tabulator(data, false, options, types, classes, T::class)
             init?.invoke(tabulator)
-            val unsubscribe = store.subscribe { s ->
+            tabulator.addAfterDisposeHook(store.subscribe { s ->
                 tabulator.replaceData(dataFactory(s).toTypedArray())
-            }
-            tabulator.afterDisposeHook = {
-                unsubscribe()
-            }
+            })
             return tabulator
         }
     }

--- a/src/main/kotlin/pl/treksoft/kvision/core/Widget.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/core/Widget.kt
@@ -248,30 +248,19 @@ open class Widget(classes: Set<String> = setOf()) : StyledComponent(), Component
         }
     }
 
-    private fun getSnAttrsInternal(): List<StringPair> {
-        if (lastLanguage != null && lastLanguage != I18n.language) snAttrsCache = null
-        return snAttrsCache ?: {
-            val s = getSnAttrs()
-            snAttrsCache = s
-            s
-        }()
-    }
+    private fun getSnAttrsInternal(): List<StringPair> =
+        snAttrsCache.let { cache ->
+            if (cache == null || lastLanguage != null && lastLanguage != I18n.language) {
+                getSnAttrs().also { snAttrsCache = it }
+            } else {
+                cache
+            }
+        }
 
-    private fun getSnClassInternal(): List<StringBoolPair> {
-        return snClassCache ?: {
-            val s = getSnClass()
-            snClassCache = s
-            s
-        }()
-    }
+    private fun getSnClassInternal(): List<StringBoolPair> = snClassCache ?: getSnClass().also { snClassCache = it }
 
-    private fun getSnHooksInternal(): com.github.snabbdom.Hooks? {
-        return snHooksCache ?: {
-            val s = getSnHooks()
-            snHooksCache = s
-            s
-        }()
-    }
+    private fun getSnHooksInternal(): com.github.snabbdom.Hooks? =
+        snHooksCache ?: getSnHooks().also { snHooksCache = it }
 
     /**
      * Returns list of CSS class names for current widget in the form of a List<StringBoolPair>.

--- a/src/main/kotlin/pl/treksoft/kvision/core/Widget.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/core/Widget.kt
@@ -118,20 +118,49 @@ open class Widget(classes: Set<String> = setOf()) : StyledComponent(), Component
 
     protected var lastLanguage: String? = null
 
-    /**
-     * A function called after the widget is inserted to the DOM.
-     */
-    var afterInsertHook: ((VNode) -> Unit)? = null
+    @Deprecated("use addAfterInsertHooks instead", ReplaceWith("addAfterInsertHook"))
+    var afterInsertHook: ((VNode) -> Unit)
+        get() {
+            throw UnsupportedOperationException()
+        }
+        set(value) {
+            addAfterInsertHook(value)
+        }
 
+    @Deprecated("use addAfterDestroyHook instead", ReplaceWith("addAfterDestroyHook"))
+    var afterDestroyHook: (() -> Unit)
+        get() {
+            throw UnsupportedOperationException()
+        }
+        set(value) {
+            addAfterDestroyHook(value)
+        }
+
+    @Deprecated("use addAfterDisposeHook instead", ReplaceWith("addAfterDisposeHook"))
+    var afterDisposeHook: () -> Unit
+        get() {
+            throw UnsupportedOperationException()
+        }
+        set(value) {
+            addAfterDisposeHook(value)
+        }
+
+    private val afterInsertHooks: MutableList<(VNode) -> Unit> = mutableListOf()
+    private val afterDestroyHooks: MutableList<() -> Unit> = mutableListOf()
+    private val afterDisposeHooks: MutableList<() -> Unit> = mutableListOf()
+
+    /**
+     * The supplied function is called after the widget is disposed.
+     */
+    fun addAfterDisposeHook(hook: () -> Unit) = afterDisposeHooks.add(hook)
+    /**
+     * The supplied function is called after the widget is destroyed.
+     */
+    fun addAfterDestroyHook(hook: () -> Unit) = afterDestroyHooks.add(hook)
     /**
      * A function called after the widget is removed from the DOM.
      */
-    var afterDestroyHook: (() -> Unit)? = null
-
-    /**
-     * A function called after the widget is disposed.
-     */
-    var afterDisposeHook: (() -> Unit)? = null
+    fun addAfterInsertHook(hook: (VNode) -> Unit) = afterInsertHooks.add(hook)
 
     protected fun <T> singleRender(block: () -> T): T {
         getRoot()?.renderDisabled = true
@@ -328,12 +357,12 @@ open class Widget(classes: Set<String> = setOf()) : StyledComponent(), Component
                 vnode = v
                 afterInsertInternal(v)
                 afterInsert(v)
-                afterInsertHook?.invoke(v)
+                afterInsertHooks.forEach { it(v) }
             }
             destroy = {
                 afterDestroyInternal()
                 afterDestroy()
-                afterDestroyHook?.invoke()
+                afterDestroyHooks.forEach { it() }
                 vnode = null
                 vnode
             }
@@ -974,7 +1003,7 @@ open class Widget(classes: Set<String> = setOf()) : StyledComponent(), Component
     }
 
     override fun dispose() {
-        afterDisposeHook?.invoke()
+        afterDisposeHooks.forEach { it() }
     }
 
     protected fun <T> refreshOnUpdate(refreshFunction: ((T) -> Unit) = { this.refresh() }): RefreshDelegateProvider<T> =
@@ -1024,15 +1053,12 @@ open class Widget(classes: Set<String> = setOf()) : StyledComponent(), Component
             removeChildren: Boolean = true,
             factory: (W.(S) -> Unit)
         ): W {
-            val unsubscribe = observableState.subscribe {
-                this.singleRender {
+            this.addAfterDisposeHook(observableState.subscribe {
+                singleRender {
                     if (removeChildren) (this as? Container)?.removeAll()
-                    this.factory(it)
+                    factory(it)
                 }
-            }
-            this.afterDisposeHook = {
-                unsubscribe()
-            }
+            })
             return this
         }
     }


### PR DESCRIPTION
While reviewing #196 and checking on how the `dispose` callbacks work, I noticed, that the `afterInsertHook` `afterDestroyHook` and `afterDisposeHook` are just public properties on `Widget`. If this property is just assigned to without care, then a hook which was already present might be overridden accidentally. I hope I did not miss anything that this would be by design?

So basically I propose to use private properties and a list one can append hooks to.

Also while working on the Widget-class I noticed some code hints from IDEA that there is an unnecessary block. I took it a step further and simplified the whole affected methods.