### PR TITLE
Replace getSnClass with a function that uses a builder

### DIFF
--- a/kvision-modules/kvision-bootstrap-datetime/src/main/kotlin/pl/treksoft/kvision/form/time/DateTime.kt
+++ b/kvision-modules/kvision-bootstrap-datetime/src/main/kotlin/pl/treksoft/kvision/form/time/DateTime.kt
@@ -21,8 +21,8 @@
  */
 package pl.treksoft.kvision.form.time
 
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringBoolPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.form.DateFormControl
 import pl.treksoft.kvision.form.FieldLabel
@@ -254,12 +254,11 @@ open class DateTime(
         counter++
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
         if (validatorError != null) {
-            cl.add("text-danger" to true)
+            classSetBuilder.add("text-danger")
         }
-        return cl
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/kvision-modules/kvision-bootstrap-datetime/src/main/kotlin/pl/treksoft/kvision/form/time/DateTimeInput.kt
+++ b/kvision-modules/kvision-bootstrap-datetime/src/main/kotlin/pl/treksoft/kvision/form/time/DateTimeInput.kt
@@ -24,8 +24,8 @@ package pl.treksoft.kvision.form.time
 import com.github.snabbdom.VNode
 import pl.treksoft.jquery.invoke
 import pl.treksoft.jquery.jQuery
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringBoolPair
 import pl.treksoft.kvision.form.FormInput
 import pl.treksoft.kvision.form.text.TextInput
 import pl.treksoft.kvision.html.Div
@@ -234,12 +234,9 @@ open class DateTimeInput(
         }
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
-        validationStatus?.let {
-            cl.add(it.className to true)
-        }
-        return cl
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
+        classSetBuilder.add(validationStatus)
     }
 
     protected open fun refreshDatePicker() {

--- a/kvision-modules/kvision-bootstrap-datetime/src/test/kotlin/test/pl/treksoft/kvision/TestUtil.kt
+++ b/kvision-modules/kvision-bootstrap-datetime/src/test/kotlin/test/pl/treksoft/kvision/TestUtil.kt
@@ -28,6 +28,8 @@ import pl.treksoft.jquery.get
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.panel.Root
 import kotlinx.browser.document
+import org.w3c.dom.asList
+import pl.treksoft.jquery.JQuery
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -70,8 +72,8 @@ interface DomSpec : TestSpec {
 
     fun assertEqualsHtml(expected: String?, actual: String?, message: String?) {
         if (expected != null && actual != null) {
-            val exp = jQuery(expected)
-            val act = jQuery(actual)
+            val exp = jQuery(expected).normalizeClassListRecursive()
+            val act = jQuery(actual).normalizeClassListRecursive()
             val result = exp[0]?.isEqualNode(act[0])
             if (result == true) {
                 assertTrue(result == true, message)
@@ -83,6 +85,19 @@ interface DomSpec : TestSpec {
         }
     }
 }
+
+private fun JQuery.normalizeClassList(): JQuery {
+    each { _, elem ->
+        elem.setAttribute("class", elem.classList.asList().sorted().joinToString(" "))
+    }
+    return this
+}
+
+private fun JQuery.normalizeClassListRecursive(): JQuery {
+    jQuery("*", this).addBack().normalizeClassList()
+    return this
+}
+
 
 interface WSpec : DomSpec {
 

--- a/kvision-modules/kvision-bootstrap-datetime/src/test/kotlin/test/pl/treksoft/kvision/form/time/DateTimeInputSpec.kt
+++ b/kvision-modules/kvision-bootstrap-datetime/src/test/kotlin/test/pl/treksoft/kvision/form/time/DateTimeInputSpec.kt
@@ -44,7 +44,7 @@ class DateTimeInputSpec : DomSpec {
             root.add(dti)
             val element = document.getElementById("test")
             val datastr = data.toStringF(dti.format)
-            assertEquals(
+            assertEqualsHtml(
                 "<div class=\"input-group date\" id=\"idti\"><input class=\"form-control\" placeholder=\"place\" type=\"text\" value=\"$datastr\"><div class=\"input-group-append\"><span class=\"input-group-text datepickerbutton\"><span class=\"fas fa-calendar-alt\"></span></span></div></div>",
                 element?.innerHTML,
                 "Should render date time input with correctly formatted value"

--- a/kvision-modules/kvision-bootstrap-select-remote/src/main/kotlin/pl/treksoft/kvision/form/select/SelectRemote.kt
+++ b/kvision-modules/kvision-bootstrap-select-remote/src/main/kotlin/pl/treksoft/kvision/form/select/SelectRemote.kt
@@ -21,9 +21,9 @@
  */
 package pl.treksoft.kvision.form.select
 
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Component
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringBoolPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.form.FieldLabel
 import pl.treksoft.kvision.form.InvalidFeedback
@@ -179,12 +179,11 @@ open class SelectRemote<T : Any>(
         counter++
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
         if (validatorError != null) {
-            cl.add("text-danger" to true)
+            classSetBuilder.add("text-danger")
         }
-        return cl
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/kvision-modules/kvision-bootstrap-select/src/main/kotlin/pl/treksoft/kvision/form/select/Select.kt
+++ b/kvision-modules/kvision-bootstrap-select/src/main/kotlin/pl/treksoft/kvision/form/select/Select.kt
@@ -21,9 +21,9 @@
  */
 package pl.treksoft.kvision.form.select
 
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Component
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringBoolPair
 import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.form.FieldLabel
@@ -220,13 +220,12 @@ open class Select(
         counter++
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
         if (validatorError != null) {
-            cl.add("text-danger" to true)
-            cl.add("select-parent" to true)
+            classSetBuilder.add("text-danger")
+            classSetBuilder.add("select-parent")
         }
-        return cl
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/kvision-modules/kvision-bootstrap-select/src/main/kotlin/pl/treksoft/kvision/form/select/SelectInput.kt
+++ b/kvision-modules/kvision-bootstrap-select/src/main/kotlin/pl/treksoft/kvision/form/select/SelectInput.kt
@@ -23,10 +23,10 @@ package pl.treksoft.kvision.form.select
 
 import com.github.snabbdom.VNode
 import pl.treksoft.kvision.KVManagerSelect.KVNULL
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Component
 import pl.treksoft.kvision.core.Container
 import pl.treksoft.kvision.core.CssSize
-import pl.treksoft.kvision.core.StringBoolPair
 import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.form.FormInput
 import pl.treksoft.kvision.form.InputSize
@@ -282,16 +282,11 @@ open class SelectInput(
         getElementJQueryD()?.selectpicker("toggle")
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
-        cl.add("selectpicker" to true)
-        validationStatus?.let {
-            cl.add(it.className to true)
-        }
-        size?.let {
-            cl.add(it.className to true)
-        }
-        return cl
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
+        classSetBuilder.add("selectpicker")
+        classSetBuilder.add(validationStatus)
+        classSetBuilder.add(size)
     }
 
     protected fun refreshSelectInput() {

--- a/kvision-modules/kvision-bootstrap-select/src/test/kotlin/test/pl/treksoft/kvision/TestUtil.kt
+++ b/kvision-modules/kvision-bootstrap-select/src/test/kotlin/test/pl/treksoft/kvision/TestUtil.kt
@@ -28,6 +28,8 @@ import pl.treksoft.jquery.get
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.panel.Root
 import kotlinx.browser.document
+import org.w3c.dom.asList
+import pl.treksoft.jquery.JQuery
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -70,8 +72,8 @@ interface DomSpec : TestSpec {
 
     fun assertEqualsHtml(expected: String?, actual: String?, message: String?) {
         if (expected != null && actual != null) {
-            val exp = jQuery(expected)
-            val act = jQuery(actual)
+            val exp = jQuery(expected).normalizeClassListRecursive()
+            val act = jQuery(actual).normalizeClassListRecursive()
             val result = exp[0]?.isEqualNode(act[0])
             if (result == true) {
                 assertTrue(result == true, message)
@@ -82,6 +84,18 @@ interface DomSpec : TestSpec {
             assertEquals(expected, actual, message)
         }
     }
+}
+
+private fun JQuery.normalizeClassList(): JQuery {
+    each { _, elem ->
+        elem.setAttribute("class", elem.classList.asList().sorted().joinToString(" "))
+    }
+    return this
+}
+
+private fun JQuery.normalizeClassListRecursive(): JQuery {
+    jQuery("*", this).addBack().normalizeClassList()
+    return this
 }
 
 interface WSpec : DomSpec {

--- a/kvision-modules/kvision-bootstrap-spinner/src/main/kotlin/pl/treksoft/kvision/form/spinner/Spinner.kt
+++ b/kvision-modules/kvision-bootstrap-spinner/src/main/kotlin/pl/treksoft/kvision/form/spinner/Spinner.kt
@@ -21,8 +21,8 @@
  */
 package pl.treksoft.kvision.form.spinner
 
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringBoolPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.form.FieldLabel
 import pl.treksoft.kvision.form.FormHorizontalRatio
@@ -206,12 +206,11 @@ open class Spinner(
         counter++
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
         if (validatorError != null) {
-            cl.add("text-danger" to true)
+            classSetBuilder.add("text-danger")
         }
-        return cl
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/kvision-modules/kvision-bootstrap-spinner/src/main/kotlin/pl/treksoft/kvision/form/spinner/SpinnerInput.kt
+++ b/kvision-modules/kvision-bootstrap-spinner/src/main/kotlin/pl/treksoft/kvision/form/spinner/SpinnerInput.kt
@@ -23,8 +23,8 @@ package pl.treksoft.kvision.form.spinner
 
 import com.github.snabbdom.VNode
 import pl.treksoft.jquery.JQuery
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringBoolPair
 import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.form.FormInput
@@ -181,15 +181,10 @@ open class SpinnerInput(
         return render("input")
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
-        validationStatus?.let {
-            cl.add(it.className to true)
-        }
-        size?.let {
-            cl.add(it.className to true)
-        }
-        return cl
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
+        classSetBuilder.add(validationStatus)
+        classSetBuilder.add(size)
     }
 
     @Suppress("ComplexMethod")

--- a/kvision-modules/kvision-bootstrap-spinner/src/test/kotlin/test/pl/treksoft/kvision/TestUtil.kt
+++ b/kvision-modules/kvision-bootstrap-spinner/src/test/kotlin/test/pl/treksoft/kvision/TestUtil.kt
@@ -28,6 +28,8 @@ import pl.treksoft.jquery.get
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.panel.Root
 import kotlinx.browser.document
+import org.w3c.dom.asList
+import pl.treksoft.jquery.JQuery
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -70,8 +72,8 @@ interface DomSpec : TestSpec {
 
     fun assertEqualsHtml(expected: String?, actual: String?, message: String?) {
         if (expected != null && actual != null) {
-            val exp = jQuery(expected)
-            val act = jQuery(actual)
+            val exp = jQuery(expected).normalizeClassListRecursive()
+            val act = jQuery(actual).normalizeClassListRecursive()
             val result = exp[0]?.isEqualNode(act[0])
             if (result == true) {
                 assertTrue(result == true, message)
@@ -82,6 +84,18 @@ interface DomSpec : TestSpec {
             assertEquals(expected, actual, message)
         }
     }
+}
+
+private fun JQuery.normalizeClassList(): JQuery {
+    each { _, elem ->
+        elem.setAttribute("class", elem.classList.asList().sorted().joinToString(" "))
+    }
+    return this
+}
+
+private fun JQuery.normalizeClassListRecursive(): JQuery {
+    jQuery("*", this).addBack().normalizeClassList()
+    return this
 }
 
 interface WSpec : DomSpec {

--- a/kvision-modules/kvision-bootstrap-typeahead/src/test/kotlin/test/pl/treksoft/kvision/TestUtil.kt
+++ b/kvision-modules/kvision-bootstrap-typeahead/src/test/kotlin/test/pl/treksoft/kvision/TestUtil.kt
@@ -28,6 +28,8 @@ import pl.treksoft.jquery.get
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.panel.Root
 import kotlinx.browser.document
+import org.w3c.dom.asList
+import pl.treksoft.jquery.JQuery
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -70,8 +72,8 @@ interface DomSpec : TestSpec {
 
     fun assertEqualsHtml(expected: String?, actual: String?, message: String?) {
         if (expected != null && actual != null) {
-            val exp = jQuery(expected)
-            val act = jQuery(actual)
+            val exp = jQuery(expected).normalizeClassListRecursive()
+            val act = jQuery(actual).normalizeClassListRecursive()
             val result = exp[0]?.isEqualNode(act[0])
             if (result == true) {
                 assertTrue(result == true, message)
@@ -82,6 +84,18 @@ interface DomSpec : TestSpec {
             assertEquals(expected, actual, message)
         }
     }
+}
+
+private fun JQuery.normalizeClassList(): JQuery {
+    each { _, elem ->
+        elem.setAttribute("class", elem.classList.asList().sorted().joinToString(" "))
+    }
+    return this
+}
+
+private fun JQuery.normalizeClassListRecursive(): JQuery {
+    jQuery("*", this).addBack().normalizeClassList()
+    return this
 }
 
 interface WSpec : DomSpec {

--- a/kvision-modules/kvision-bootstrap-upload/src/main/kotlin/pl/treksoft/kvision/form/upload/Upload.kt
+++ b/kvision-modules/kvision-bootstrap-upload/src/main/kotlin/pl/treksoft/kvision/form/upload/Upload.kt
@@ -22,8 +22,8 @@
 package pl.treksoft.kvision.form.upload
 
 import org.w3c.files.File
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringBoolPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.form.FieldLabel
 import pl.treksoft.kvision.form.InvalidFeedback
@@ -248,12 +248,11 @@ open class Upload(
         counter++
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
         if (validatorError != null) {
-            cl.add("text-danger" to true)
+            classSetBuilder.add("text-danger")
         }
-        return cl
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/kvision-modules/kvision-bootstrap-upload/src/main/kotlin/pl/treksoft/kvision/form/upload/UploadInput.kt
+++ b/kvision-modules/kvision-bootstrap-upload/src/main/kotlin/pl/treksoft/kvision/form/upload/UploadInput.kt
@@ -23,8 +23,8 @@ package pl.treksoft.kvision.form.upload
 
 import com.github.snabbdom.VNode
 import org.w3c.files.File
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringBoolPair
 import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.form.Form
@@ -174,15 +174,10 @@ open class UploadInput(uploadUrl: String? = null, multiple: Boolean = false, cla
         return render("input")
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
-        validationStatus?.let {
-            cl.add(it.className to true)
-        }
-        size?.let {
-            cl.add(it.className to true)
-        }
-        return cl
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
+        classSetBuilder.add(validationStatus)
+        classSetBuilder.add(size)
     }
 
     override fun getSnAttrs(): List<StringPair> {

--- a/kvision-modules/kvision-bootstrap-upload/src/test/kotlin/test/pl/treksoft/kvision/TestUtil.kt
+++ b/kvision-modules/kvision-bootstrap-upload/src/test/kotlin/test/pl/treksoft/kvision/TestUtil.kt
@@ -28,6 +28,8 @@ import pl.treksoft.jquery.get
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.panel.Root
 import kotlinx.browser.document
+import org.w3c.dom.asList
+import pl.treksoft.jquery.JQuery
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -70,8 +72,8 @@ interface DomSpec : TestSpec {
 
     fun assertEqualsHtml(expected: String?, actual: String?, message: String?) {
         if (expected != null && actual != null) {
-            val exp = jQuery(expected)
-            val act = jQuery(actual)
+            val exp = jQuery(expected).normalizeClassListRecursive()
+            val act = jQuery(actual).normalizeClassListRecursive()
             val result = exp[0]?.isEqualNode(act[0])
             if (result == true) {
                 assertTrue(result == true, message)
@@ -82,6 +84,18 @@ interface DomSpec : TestSpec {
             assertEquals(expected, actual, message)
         }
     }
+}
+
+private fun JQuery.normalizeClassList(): JQuery {
+    each { _, elem ->
+        elem.setAttribute("class", elem.classList.asList().sorted().joinToString(" "))
+    }
+    return this
+}
+
+private fun JQuery.normalizeClassListRecursive(): JQuery {
+    jQuery("*", this).addBack().normalizeClassList()
+    return this
 }
 
 interface WSpec : DomSpec {

--- a/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/core/Component.kt
+++ b/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/core/Component.kt
@@ -111,7 +111,7 @@ fun Component.removeBsColor(bsColor: BsColor) {
     this.removeCssClass(bsColor.className)
 }
 
-enum class BsBgColor(internal val className: String) {
+enum class BsBgColor(override val className: String) : CssClass {
     PRIMARY("bg-primary"),
     SECONDARY("bg-secondary"),
     SUCCESS("bg-success"),

--- a/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/dropdown/DropDown.kt
+++ b/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/dropdown/DropDown.kt
@@ -22,11 +22,11 @@
 package pl.treksoft.kvision.dropdown
 
 import com.github.snabbdom.VNode
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Component
 import pl.treksoft.kvision.core.Container
 import pl.treksoft.kvision.core.CssSize
 import pl.treksoft.kvision.core.ResString
-import pl.treksoft.kvision.core.StringBoolPair
 import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.html.Button
 import pl.treksoft.kvision.html.ButtonStyle
@@ -241,11 +241,10 @@ open class DropDown(
         }
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
-        if (forNavbar) cl.add("nav-item" to true)
-        cl.add(direction.direction to true)
-        return cl
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
+        if (forNavbar) classSetBuilder.add("nav-item")
+        classSetBuilder.add(direction.direction)
     }
 
     /**
@@ -452,11 +451,12 @@ class DropDownButton(
         }
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        return when {
-            forNavbar -> listOf("nav-link" to true, "dropdown-toggle" to true)
-            forDropDown -> super.getSnClass() + listOf("dropdown-item" to true, "dropdown-toggle" to true)
-            else -> super.getSnClass() + ("dropdown-toggle" to true)
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        classSetBuilder.add("dropdown-toggle")
+        when {
+            forNavbar -> classSetBuilder.add("nav-link")
+            forDropDown -> classSetBuilder.run { super.buildClassSet(this); add("dropdown-item") }
+            else -> super.buildClassSet(classSetBuilder)
         }
     }
 

--- a/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/modal/CloseIcon.kt
+++ b/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/modal/CloseIcon.kt
@@ -23,7 +23,7 @@ package pl.treksoft.kvision.modal
 
 import com.github.snabbdom.VNode
 import pl.treksoft.kvision.KVManager
-import pl.treksoft.kvision.core.StringBoolPair
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.core.Widget
 
@@ -36,10 +36,9 @@ open class CloseIcon : Widget(setOf()) {
         return render("button", arrayOf(KVManager.virtualize("<span aria-hidden='true'>&times;</span>")))
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
-        cl.add("close" to true)
-        return cl
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
+        classSetBuilder.add("close")
     }
 
     override fun getSnAttrs(): List<StringPair> {

--- a/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/modal/Modal.kt
+++ b/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/modal/Modal.kt
@@ -22,9 +22,10 @@
 package pl.treksoft.kvision.modal
 
 import com.github.snabbdom.VNode
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Component
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringBoolPair
+import pl.treksoft.kvision.core.CssClass
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.html.Button
 import pl.treksoft.kvision.html.TAG
@@ -38,7 +39,7 @@ import pl.treksoft.kvision.utils.obj
 /**
  * Modal window sizes.
  */
-enum class ModalSize(val className: String) {
+enum class ModalSize(override val className: String) : CssClass {
     XLARGE("modal-xl"),
     LARGE("modal-lg"),
     SMALL("modal-sm")
@@ -224,13 +225,12 @@ open class Modal(
         return this
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
-        cl.add("modal" to true)
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
+        classSetBuilder.add("modal")
         if (animation) {
-            cl.add("fade" to true)
+            classSetBuilder.add("fade")
         }
-        return cl
     }
 
     @Suppress("UnsafeCastFromDynamic")
@@ -320,17 +320,14 @@ internal class ModalDialog(size: ModalSize?, centered: Boolean = false, scrollab
      */
     var scrollable by refreshOnUpdate(scrollable)
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
-        size?.let {
-            cl.add(it.className to true)
-        }
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
+        classSetBuilder.add(size)
         if (centered) {
-            cl.add("modal-dialog-centered" to true)
+            classSetBuilder.add("modal-dialog-centered")
         }
         if (scrollable) {
-            cl.add("modal-dialog-scrollable" to true)
+            classSetBuilder.add("modal-dialog-scrollable")
         }
-        return cl
     }
 }

--- a/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/navbar/Nav.kt
+++ b/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/navbar/Nav.kt
@@ -21,8 +21,8 @@
  */
 package pl.treksoft.kvision.navbar
 
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.ResString
-import pl.treksoft.kvision.core.StringBoolPair
 import pl.treksoft.kvision.html.Div
 import pl.treksoft.kvision.html.Link
 import pl.treksoft.kvision.state.ObservableState
@@ -50,13 +50,12 @@ open class Nav(rightAlign: Boolean = false, classes: Set<String> = setOf(), init
         init?.invoke(this)
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
-        cl.add("navbar-nav" to true)
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
+        classSetBuilder.add("navbar-nav")
         if (rightAlign) {
-            cl.add("ml-auto" to true)
+            classSetBuilder.add("ml-auto")
         }
-        return cl
     }
 }
 

--- a/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/navbar/NavForm.kt
+++ b/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/navbar/NavForm.kt
@@ -21,7 +21,7 @@
  */
 package pl.treksoft.kvision.navbar
 
-import pl.treksoft.kvision.core.StringBoolPair
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.html.TAG
 import pl.treksoft.kvision.html.Tag
 import pl.treksoft.kvision.state.ObservableState
@@ -49,13 +49,12 @@ open class NavForm(rightAlign: Boolean = false, classes: Set<String> = setOf(), 
         init?.invoke(this)
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
-        cl.add("form-inline" to true)
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
+        classSetBuilder.add("form-inline")
         if (rightAlign) {
-            cl.add("ml-auto" to true)
+            classSetBuilder.add("ml-auto")
         }
-        return cl
     }
 }
 

--- a/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/navbar/Navbar.kt
+++ b/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/navbar/Navbar.kt
@@ -25,9 +25,10 @@ import com.github.snabbdom.VNode
 import pl.treksoft.jquery.invoke
 import pl.treksoft.jquery.jQuery
 import pl.treksoft.kvision.core.BsBgColor
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Component
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringBoolPair
+import pl.treksoft.kvision.core.CssClass
 import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.html.Link
 import pl.treksoft.kvision.html.Span
@@ -40,7 +41,7 @@ import pl.treksoft.kvision.utils.set
 /**
  * Navbar types.
  */
-enum class NavbarType(internal val navbarType: String) {
+enum class NavbarType(override val className: String) : CssClass {
     FIXEDTOP("fixed-top"),
     FIXEDBOTTOM("fixed-bottom"),
     STICKYTOP("sticky-top")
@@ -57,7 +58,7 @@ enum class NavbarColor(internal val navbarColor: String) {
 /**
  * Navbar responsive behavior.
  */
-enum class NavbarExpand(internal val navbarExpand: String) {
+enum class NavbarExpand(override val className: String) : CssClass {
     ALWAYS("navbar-expand"),
     XL("navbar-expand-xl"),
     LG("navbar-expand-lg"),
@@ -191,18 +192,13 @@ open class Navbar(
         return container.getChildren()
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
-        cl.add("navbar" to true)
-        type?.let {
-            cl.add(it.navbarType to true)
-        }
-        expand?.let {
-            cl.add(it.navbarExpand to true)
-        }
-        cl.add(nColor.navbarColor to true)
-        cl.add(bgColor.className to true)
-        return cl
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
+        classSetBuilder.add("navbar")
+        classSetBuilder.add(type)
+        classSetBuilder.add(expand)
+        classSetBuilder.add(nColor.navbarColor)
+        classSetBuilder.add(bgColor.className)
     }
 
     companion object {

--- a/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/progress/ProgressBar.kt
+++ b/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/progress/ProgressBar.kt
@@ -21,8 +21,9 @@
  */
 package pl.treksoft.kvision.progress
 
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringBoolPair
+import pl.treksoft.kvision.core.CssClass
 import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.html.Align
 import pl.treksoft.kvision.html.Div
@@ -40,7 +41,7 @@ import pl.treksoft.kvision.utils.set
     "Use Progress component instead with BsBgColor enum value.",
     replaceWith = ReplaceWith("BsBgColor", "pl.treksoft.kvision.core.BsBgColor")
 )
-enum class ProgressBarStyle(internal val className: String) {
+enum class ProgressBarStyle(override val className: String) : CssClass {
     SUCCESS("bg-success"),
     INFO("bg-info"),
     WARNING("bg-warning"),
@@ -234,19 +235,16 @@ internal class ProgressIndicator(
         width = percent.perc
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
-        cl.add("progress-bar" to true)
-        style?.let {
-            cl.add(it.className to true)
-        }
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
+        classSetBuilder.add("progress-bar")
+        classSetBuilder.add(style)
         if (striped || animated) {
-            cl.add("progress-bar-striped" to true)
+            classSetBuilder.add("progress-bar-striped")
         }
         if (animated) {
-            cl.add("progress-bar-animated" to true)
+            classSetBuilder.add("progress-bar-animated")
         }
-        return cl
     }
 
     override fun getSnAttrs(): List<StringPair> {

--- a/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/progress/ProgressBarTag.kt
+++ b/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/progress/ProgressBarTag.kt
@@ -25,7 +25,7 @@ package pl.treksoft.kvision.progress
 
 import pl.treksoft.kvision.core.AttributeDelegate
 import pl.treksoft.kvision.core.BsBgColor
-import pl.treksoft.kvision.core.StringBoolPair
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.html.Div
 import pl.treksoft.kvision.utils.perc
 
@@ -63,19 +63,16 @@ abstract class ProgressBarTag<T>(classes: Set<String> = setOf(), bgColor: BsBgCo
      */
     abstract var value: T
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
-        cl.add("progress-bar" to true)
-        style?.let {
-            cl.add(it.className to true)
-        }
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
+        classSetBuilder.add("progress-bar")
+        classSetBuilder.add(style)
         if (striped || animated) {
-            cl.add("progress-bar-striped" to true)
+            classSetBuilder.add("progress-bar-striped")
         }
         if (animated) {
-            cl.add("progress-bar-animated" to true)
+            classSetBuilder.add("progress-bar-animated")
         }
-        return cl
     }
 
     protected fun setFraction(fraction: Double) {

--- a/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/toolbar/ButtonGroup.kt
+++ b/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/toolbar/ButtonGroup.kt
@@ -21,8 +21,9 @@
  */
 package pl.treksoft.kvision.toolbar
 
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringBoolPair
+import pl.treksoft.kvision.core.CssClass
 import pl.treksoft.kvision.panel.SimplePanel
 import pl.treksoft.kvision.state.ObservableState
 import pl.treksoft.kvision.state.bind
@@ -32,7 +33,7 @@ import pl.treksoft.kvision.utils.set
 /**
  * Button group sizes.
  */
-enum class ButtonGroupSize(internal val className: String) {
+enum class ButtonGroupSize(override val className: String) : CssClass {
     LARGE("btn-group-lg"),
     SMALL("btn-group-sm")
 }
@@ -67,17 +68,10 @@ open class ButtonGroup(
         init?.invoke(this)
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
-        if (vertical) {
-            cl.add("btn-group-vertical" to true)
-        } else {
-            cl.add("btn-group" to true)
-        }
-        size?.let {
-            cl.add(it.className to true)
-        }
-        return cl
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
+        classSetBuilder.add(if (vertical) "btn-group-vertical" else "btn-group")
+        classSetBuilder.add(size)
     }
 }
 

--- a/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/window/MaximizeIcon.kt
+++ b/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/window/MaximizeIcon.kt
@@ -23,7 +23,7 @@ package pl.treksoft.kvision.window
 
 import com.github.snabbdom.VNode
 import pl.treksoft.kvision.KVManager
-import pl.treksoft.kvision.core.StringBoolPair
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.core.Widget
 
@@ -36,10 +36,9 @@ open class MaximizeIcon : Widget(setOf()) {
         return render("button", arrayOf(KVManager.virtualize("<span aria-hidden='true'>&#x1f5d6;</span>")))
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
-        cl.add("close" to true)
-        return cl
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
+        classSetBuilder.add("close")
     }
 
     override fun getSnAttrs(): List<StringPair> {

--- a/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/window/MinimizeIcon.kt
+++ b/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/window/MinimizeIcon.kt
@@ -23,7 +23,7 @@ package pl.treksoft.kvision.window
 
 import com.github.snabbdom.VNode
 import pl.treksoft.kvision.KVManager
-import pl.treksoft.kvision.core.StringBoolPair
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.core.Widget
 
@@ -36,10 +36,9 @@ open class MinimizeIcon : Widget(setOf()) {
         return render("button", arrayOf(KVManager.virtualize("<span aria-hidden='true'>&#x1f5d5;</span>")))
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
-        cl.add("close" to true)
-        return cl
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
+        classSetBuilder.add("close")
     }
 
     override fun getSnAttrs(): List<StringPair> {

--- a/kvision-modules/kvision-bootstrap/src/test/kotlin/test/pl/treksoft/kvision/TestUtil.kt
+++ b/kvision-modules/kvision-bootstrap/src/test/kotlin/test/pl/treksoft/kvision/TestUtil.kt
@@ -28,6 +28,8 @@ import pl.treksoft.jquery.get
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.panel.Root
 import kotlinx.browser.document
+import org.w3c.dom.asList
+import pl.treksoft.jquery.JQuery
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -72,8 +74,8 @@ interface DomSpec : TestSpec {
 
     fun assertEqualsHtml(expected: String?, actual: String?, message: String?) {
         if (expected != null && actual != null) {
-            val exp = jQuery(expected.replace("position: ;","position: absolute;"))
-            val act = jQuery(actual.replace("position: ;","position: absolute;"))
+            val exp = jQuery(expected.replace("position: ;","position: absolute;")).normalizeClassListRecursive()
+            val act = jQuery(actual.replace("position: ;","position: absolute;")).normalizeClassListRecursive()
             val result = exp[0]?.isEqualNode(act[0])
             if (result == true) {
                 assertTrue(result == true, message)
@@ -84,6 +86,18 @@ interface DomSpec : TestSpec {
             assertEquals(expected, actual, message)
         }
     }
+}
+
+private fun JQuery.normalizeClassList(): JQuery {
+    each { _, elem ->
+        elem.setAttribute("class", elem.classList.asList().sorted().joinToString(" "))
+    }
+    return this
+}
+
+private fun JQuery.normalizeClassListRecursive(): JQuery {
+    jQuery("*", this).addBack().normalizeClassList()
+    return this
 }
 
 interface WSpec : DomSpec {

--- a/kvision-modules/kvision-chart/src/test/kotlin/test/pl/treksoft/kvision/TestUtil.kt
+++ b/kvision-modules/kvision-chart/src/test/kotlin/test/pl/treksoft/kvision/TestUtil.kt
@@ -28,6 +28,8 @@ import pl.treksoft.jquery.get
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.panel.Root
 import kotlinx.browser.document
+import org.w3c.dom.asList
+import pl.treksoft.jquery.JQuery
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -70,8 +72,8 @@ interface DomSpec : TestSpec {
 
     fun assertEqualsHtml(expected: String?, actual: String?, message: String?) {
         if (expected != null && actual != null) {
-            val exp = jQuery(expected)
-            val act = jQuery(actual)
+            val exp = jQuery(expected).normalizeClassListRecursive()
+            val act = jQuery(actual).normalizeClassListRecursive()
             val result = exp[0]?.isEqualNode(act[0])
             if (result == true) {
                 assertTrue(result == true, message)
@@ -82,6 +84,18 @@ interface DomSpec : TestSpec {
             assertEquals(expected, actual, message)
         }
     }
+}
+
+private fun JQuery.normalizeClassList(): JQuery {
+    each { _, elem ->
+        elem.setAttribute("class", elem.classList.asList().sorted().joinToString(" "))
+    }
+    return this
+}
+
+private fun JQuery.normalizeClassListRecursive(): JQuery {
+    jQuery("*", this).addBack().normalizeClassList()
+    return this
 }
 
 interface WSpec : DomSpec {

--- a/kvision-modules/kvision-datacontainer/src/test/kotlin/test/pl/treksoft/kvision/TestUtil.kt
+++ b/kvision-modules/kvision-datacontainer/src/test/kotlin/test/pl/treksoft/kvision/TestUtil.kt
@@ -28,6 +28,8 @@ import pl.treksoft.jquery.get
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.panel.Root
 import kotlinx.browser.document
+import org.w3c.dom.asList
+import pl.treksoft.jquery.JQuery
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -70,8 +72,8 @@ interface DomSpec : TestSpec {
 
     fun assertEqualsHtml(expected: String?, actual: String?, message: String?) {
         if (expected != null && actual != null) {
-            val exp = jQuery(expected)
-            val act = jQuery(actual)
+            val exp = jQuery(expected).normalizeClassListRecursive()
+            val act = jQuery(actual).normalizeClassListRecursive()
             val result = exp[0]?.isEqualNode(act[0])
             if (result == true) {
                 assertTrue(result == true, message)
@@ -82,6 +84,18 @@ interface DomSpec : TestSpec {
             assertEquals(expected, actual, message)
         }
     }
+}
+
+private fun JQuery.normalizeClassList(): JQuery {
+    each { _, elem ->
+        elem.setAttribute("class", elem.classList.asList().sorted().joinToString(" "))
+    }
+    return this
+}
+
+private fun JQuery.normalizeClassListRecursive(): JQuery {
+    jQuery("*", this).addBack().normalizeClassList()
+    return this
 }
 
 interface WSpec : DomSpec {

--- a/kvision-modules/kvision-maps/src/test/kotlin/test/pl/treksoft/kvision/TestUtil.kt
+++ b/kvision-modules/kvision-maps/src/test/kotlin/test/pl/treksoft/kvision/TestUtil.kt
@@ -29,6 +29,8 @@ import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.panel.ContainerType
 import pl.treksoft.kvision.panel.Root
 import kotlinx.browser.document
+import org.w3c.dom.asList
+import pl.treksoft.jquery.JQuery
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -71,8 +73,8 @@ interface DomSpec : TestSpec {
 
     fun assertEqualsHtml(expected: String?, actual: String?, message: String?) {
         if (expected != null && actual != null) {
-            val exp = jQuery(expected)
-            val act = jQuery(actual)
+            val exp = jQuery(expected).normalizeClassListRecursive()
+            val act = jQuery(actual).normalizeClassListRecursive()
             val result = exp[0]?.isEqualNode(act[0])
             if (result == true) {
                 assertTrue(result == true, message)
@@ -83,6 +85,18 @@ interface DomSpec : TestSpec {
             assertEquals(expected, actual, message)
         }
     }
+}
+
+private fun JQuery.normalizeClassList(): JQuery {
+    each { _, elem ->
+        elem.setAttribute("class", elem.classList.asList().sorted().joinToString(" "))
+    }
+    return this
+}
+
+private fun JQuery.normalizeClassListRecursive(): JQuery {
+    jQuery("*", this).addBack().normalizeClassList()
+    return this
 }
 
 interface WSpec : DomSpec {

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/form/OnsButton.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/form/OnsButton.kt
@@ -23,8 +23,8 @@
 package pl.treksoft.kvision.onsenui.form
 
 import org.w3c.dom.events.MouseEvent
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringBoolPair
 import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.html.Align
 import pl.treksoft.kvision.html.CustomTag
@@ -111,12 +111,11 @@ open class OnsButton(
         @Suppress("UnsafeCastFromDynamic")
         get() = getElement()?.asDynamic()?.disabled
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val sn = super.getSnClass().toMutableList()
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
         if (content != null) {
-            sn.add("kv-button-with-text" to true)
+            classSetBuilder.add("kv-button-with-text")
         }
-        return sn
     }
 
     override fun getSnAttrs(): List<StringPair> {

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/form/OnsCheckBox.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/form/OnsCheckBox.kt
@@ -21,8 +21,8 @@
  */
 package pl.treksoft.kvision.onsenui.form
 
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringBoolPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.form.BoolFormControl
 import pl.treksoft.kvision.form.FieldLabel
@@ -118,12 +118,11 @@ open class OnsCheckBox(
         counter++
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
         if (validatorError != null) {
-            cl.add("text-danger" to true)
+            classSetBuilder.add("text-danger")
         }
-        return cl
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/form/OnsDateTime.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/form/OnsDateTime.kt
@@ -21,8 +21,8 @@
  */
 package pl.treksoft.kvision.onsenui.form
 
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringBoolPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.form.DateFormControl
 import pl.treksoft.kvision.form.FieldLabel
@@ -181,12 +181,11 @@ open class OnsDateTime(
         counter++
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
         if (validatorError != null) {
-            cl.add("text-danger" to true)
+            classSetBuilder.add("text-danger")
         }
-        return cl
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/form/OnsDateTimeInput.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/form/OnsDateTimeInput.kt
@@ -23,8 +23,8 @@
 package pl.treksoft.kvision.onsenui.form
 
 import com.github.snabbdom.VNode
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringBoolPair
 import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.form.FormInput
@@ -163,15 +163,10 @@ open class OnsDateTimeInput(
         return render("ons-input")
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
-        validationStatus?.let {
-            cl.add(it.className to true)
-        }
-        size?.let {
-            cl.add(it.className to true)
-        }
-        return cl
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
+        classSetBuilder.add(validationStatus)
+        classSetBuilder.add(size)
     }
 
     override fun getSnAttrs(): List<StringPair> {

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/form/OnsNumber.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/form/OnsNumber.kt
@@ -21,9 +21,9 @@
  */
 package pl.treksoft.kvision.onsenui.form
 
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Container
 import pl.treksoft.kvision.core.Display
-import pl.treksoft.kvision.core.StringBoolPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.form.FieldLabel
 import pl.treksoft.kvision.form.InvalidFeedback
@@ -209,12 +209,11 @@ open class OnsNumber(
         counter++
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
         if (validatorError != null) {
-            cl.add("text-danger" to true)
+            classSetBuilder.add("text-danger")
         }
-        return cl
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/form/OnsNumberInput.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/form/OnsNumberInput.kt
@@ -23,8 +23,8 @@
 package pl.treksoft.kvision.onsenui.form
 
 import com.github.snabbdom.VNode
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringBoolPair
 import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.form.FormInput
@@ -160,15 +160,10 @@ open class OnsNumberInput(
         return render("ons-input")
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
-        validationStatus?.let {
-            cl.add(it.className to true)
-        }
-        size?.let {
-            cl.add(it.className to true)
-        }
-        return cl
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
+        classSetBuilder.add(validationStatus)
+        classSetBuilder.add(size)
     }
 
     override fun getSnAttrs(): List<StringPair> {

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/form/OnsRadio.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/form/OnsRadio.kt
@@ -21,8 +21,8 @@
  */
 package pl.treksoft.kvision.onsenui.form
 
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringBoolPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.form.BoolFormControl
 import pl.treksoft.kvision.form.FieldLabel
@@ -130,12 +130,11 @@ open class OnsRadio(
         counter++
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
         if (validatorError != null) {
-            cl.add("text-danger" to true)
+            classSetBuilder.add("text-danger")
         }
-        return cl
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/form/OnsRadioGroup.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/form/OnsRadioGroup.kt
@@ -21,9 +21,9 @@
  */
 package pl.treksoft.kvision.onsenui.form
 
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Component
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringBoolPair
 import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.form.FieldLabel
 import pl.treksoft.kvision.form.InputSize
@@ -154,12 +154,11 @@ open class OnsRadioGroup(
         counter++
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
         if (validatorError != null) {
-            cl.add("text-danger" to true)
+            classSetBuilder.add("text-danger")
         }
-        return cl
     }
 
     private fun setValueToChildren(value: String?) {

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/form/OnsRange.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/form/OnsRange.kt
@@ -21,8 +21,8 @@
  */
 package pl.treksoft.kvision.onsenui.form
 
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringBoolPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.form.FieldLabel
 import pl.treksoft.kvision.form.InvalidFeedback
@@ -168,12 +168,11 @@ open class OnsRange(
         counter++
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
         if (validatorError != null) {
-            cl.add("text-danger" to true)
+            classSetBuilder.add("text-danger")
         }
-        return cl
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/form/OnsSelect.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/form/OnsSelect.kt
@@ -21,9 +21,9 @@
  */
 package pl.treksoft.kvision.onsenui.form
 
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Component
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringBoolPair
 import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.form.FieldLabel
@@ -173,12 +173,11 @@ open class OnsSelect(
         counter++
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
         if (validatorError != null) {
-            cl.add("text-danger" to true)
+            classSetBuilder.add("text-danger")
         }
-        return cl
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/form/OnsSwitch.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/form/OnsSwitch.kt
@@ -21,8 +21,8 @@
  */
 package pl.treksoft.kvision.onsenui.form
 
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringBoolPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.form.BoolFormControl
 import pl.treksoft.kvision.form.FieldLabel
@@ -118,12 +118,11 @@ open class OnsSwitch(
         counter++
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
         if (validatorError != null) {
-            cl.add("text-danger" to true)
+            classSetBuilder.add("text-danger")
         }
-        return cl
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/toolbar/ToolbarButton.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/toolbar/ToolbarButton.kt
@@ -23,7 +23,7 @@
 package pl.treksoft.kvision.onsenui.toolbar
 
 import org.w3c.dom.events.MouseEvent
-import pl.treksoft.kvision.core.StringBoolPair
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.html.Align
 import pl.treksoft.kvision.html.CustomTag
@@ -93,12 +93,11 @@ open class ToolbarButton(
         return sn
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val sn = super.getSnClass().toMutableList()
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
         if (content != null) {
-            sn.add("kv-button-with-text" to true)
+            classSetBuilder.add("kv-button-with-text")
         }
-        return sn
     }
 
     /**

--- a/kvision-modules/kvision-onsenui/src/test/kotlin/test/pl/treksoft/kvision/TestUtil.kt
+++ b/kvision-modules/kvision-onsenui/src/test/kotlin/test/pl/treksoft/kvision/TestUtil.kt
@@ -28,6 +28,8 @@ import pl.treksoft.jquery.get
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.panel.Root
 import kotlinx.browser.document
+import org.w3c.dom.asList
+import pl.treksoft.jquery.JQuery
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -70,8 +72,8 @@ interface DomSpec : TestSpec {
 
     fun assertEqualsHtml(expected: String?, actual: String?, message: String?) {
         if (expected != null && actual != null) {
-            val exp = jQuery(expected.replace("position: ;","position: absolute;"))
-            val act = jQuery(actual.replace("position: ;","position: absolute;"))
+            val exp = jQuery(expected.replace("position: ;","position: absolute;")).normalizeClassListRecursive()
+            val act = jQuery(actual.replace("position: ;","position: absolute;")).normalizeClassListRecursive()
             val result = exp[0]?.isEqualNode(act[0])
             if (result == true) {
                 assertTrue(result == true, message)
@@ -82,6 +84,18 @@ interface DomSpec : TestSpec {
             assertEquals(expected, actual, message)
         }
     }
+}
+
+private fun JQuery.normalizeClassList(): JQuery {
+    each { _, elem ->
+        elem.setAttribute("class", elem.classList.asList().sorted().joinToString(" "))
+    }
+    return this
+}
+
+private fun JQuery.normalizeClassListRecursive(): JQuery {
+    jQuery("*", this).addBack().normalizeClassList()
+    return this
 }
 
 interface WSpec : DomSpec {

--- a/kvision-modules/kvision-react/src/test/kotlin/test/pl/treksoft/kvision/TestUtil.kt
+++ b/kvision-modules/kvision-react/src/test/kotlin/test/pl/treksoft/kvision/TestUtil.kt
@@ -28,6 +28,8 @@ import pl.treksoft.jquery.get
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.panel.Root
 import kotlinx.browser.document
+import org.w3c.dom.asList
+import pl.treksoft.jquery.JQuery
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -70,8 +72,8 @@ interface DomSpec : TestSpec {
 
     fun assertEqualsHtml(expected: String?, actual: String?, message: String?) {
         if (expected != null && actual != null) {
-            val exp = jQuery(expected)
-            val act = jQuery(actual)
+            val exp = jQuery(expected).normalizeClassListRecursive()
+            val act = jQuery(actual).normalizeClassListRecursive()
             val result = exp[0]?.isEqualNode(act[0])
             if (result == true) {
                 assertTrue(result == true, message)
@@ -82,6 +84,18 @@ interface DomSpec : TestSpec {
             assertEquals(expected, actual, message)
         }
     }
+}
+
+private fun JQuery.normalizeClassList(): JQuery {
+    each { _, elem ->
+        elem.setAttribute("class", elem.classList.asList().sorted().joinToString(" "))
+    }
+    return this
+}
+
+private fun JQuery.normalizeClassListRecursive(): JQuery {
+    jQuery("*", this).addBack().normalizeClassList()
+    return this
 }
 
 interface WSpec : DomSpec {

--- a/kvision-modules/kvision-redux-kotlin/src/test/kotlin/test/pl/treksoft/kvision/TestUtil.kt
+++ b/kvision-modules/kvision-redux-kotlin/src/test/kotlin/test/pl/treksoft/kvision/TestUtil.kt
@@ -28,6 +28,8 @@ import pl.treksoft.jquery.get
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.panel.Root
 import kotlinx.browser.document
+import org.w3c.dom.asList
+import pl.treksoft.jquery.JQuery
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -70,8 +72,8 @@ interface DomSpec : TestSpec {
 
     fun assertEqualsHtml(expected: String?, actual: String?, message: String?) {
         if (expected != null && actual != null) {
-            val exp = jQuery(expected)
-            val act = jQuery(actual)
+            val exp = jQuery(expected).normalizeClassListRecursive()
+            val act = jQuery(actual).normalizeClassListRecursive()
             val result = exp[0]?.isEqualNode(act[0])
             if (result == true) {
                 assertTrue(result == true, message)
@@ -82,6 +84,18 @@ interface DomSpec : TestSpec {
             assertEquals(expected, actual, message)
         }
     }
+}
+
+private fun JQuery.normalizeClassList(): JQuery {
+    each { _, elem ->
+        elem.setAttribute("class", elem.classList.asList().sorted().joinToString(" "))
+    }
+    return this
+}
+
+private fun JQuery.normalizeClassListRecursive(): JQuery {
+    jQuery("*", this).addBack().normalizeClassList()
+    return this
 }
 
 interface WSpec : DomSpec {

--- a/kvision-modules/kvision-redux/src/test/kotlin/test/pl/treksoft/kvision/TestUtil.kt
+++ b/kvision-modules/kvision-redux/src/test/kotlin/test/pl/treksoft/kvision/TestUtil.kt
@@ -28,6 +28,8 @@ import pl.treksoft.jquery.get
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.panel.Root
 import kotlinx.browser.document
+import org.w3c.dom.asList
+import pl.treksoft.jquery.JQuery
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -70,8 +72,8 @@ interface DomSpec : TestSpec {
 
     fun assertEqualsHtml(expected: String?, actual: String?, message: String?) {
         if (expected != null && actual != null) {
-            val exp = jQuery(expected)
-            val act = jQuery(actual)
+            val exp = jQuery(expected).normalizeClassListRecursive()
+            val act = jQuery(actual).normalizeClassListRecursive()
             val result = exp[0]?.isEqualNode(act[0])
             if (result == true) {
                 assertTrue(result == true, message)
@@ -82,6 +84,18 @@ interface DomSpec : TestSpec {
             assertEquals(expected, actual, message)
         }
     }
+}
+
+private fun JQuery.normalizeClassList(): JQuery {
+    each { _, elem ->
+        elem.setAttribute("class", elem.classList.asList().sorted().joinToString(" "))
+    }
+    return this
+}
+
+private fun JQuery.normalizeClassListRecursive(): JQuery {
+    jQuery("*", this).addBack().normalizeClassList()
+    return this
 }
 
 interface WSpec : DomSpec {

--- a/kvision-modules/kvision-richtext/src/test/kotlin/test/pl/treksoft/kvision/TestUtil.kt
+++ b/kvision-modules/kvision-richtext/src/test/kotlin/test/pl/treksoft/kvision/TestUtil.kt
@@ -28,6 +28,8 @@ import pl.treksoft.jquery.get
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.panel.Root
 import kotlinx.browser.document
+import org.w3c.dom.asList
+import pl.treksoft.jquery.JQuery
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -70,8 +72,8 @@ interface DomSpec : TestSpec {
 
     fun assertEqualsHtml(expected: String?, actual: String?, message: String?) {
         if (expected != null && actual != null) {
-            val exp = jQuery(expected)
-            val act = jQuery(actual)
+            val exp = jQuery(expected).normalizeClassListRecursive()
+            val act = jQuery(actual).normalizeClassListRecursive()
             val result = exp[0]?.isEqualNode(act[0])
             if (result == true) {
                 assertTrue(result == true, message)
@@ -82,6 +84,18 @@ interface DomSpec : TestSpec {
             assertEquals(expected, actual, message)
         }
     }
+}
+
+private fun JQuery.normalizeClassList(): JQuery {
+    each { _, elem ->
+        elem.setAttribute("class", elem.classList.asList().sorted().joinToString(" "))
+    }
+    return this
+}
+
+private fun JQuery.normalizeClassListRecursive(): JQuery {
+    jQuery("*", this).addBack().normalizeClassList()
+    return this
 }
 
 interface WSpec : DomSpec {

--- a/kvision-modules/kvision-tabulator/src/main/kotlin/pl/treksoft/kvision/tabulator/Tabulator.kt
+++ b/kvision-modules/kvision-tabulator/src/main/kotlin/pl/treksoft/kvision/tabulator/Tabulator.kt
@@ -25,8 +25,8 @@ import com.github.snabbdom.VNode
 import kotlinx.browser.window
 import org.w3c.dom.HTMLElement
 import pl.treksoft.kvision.KVManagerTabulator
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringBoolPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.i18n.I18n
 import pl.treksoft.kvision.state.ObservableList
@@ -210,12 +210,11 @@ open class Tabulator<T : Any>(
         }
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
         types.forEach {
-            cl.add(it.type to true)
+            classSetBuilder.add(it.type)
         }
-        return cl
     }
 
     /**

--- a/kvision-modules/kvision-tabulator/src/test/kotlin/test/pl/treksoft/kvision/TestUtil.kt
+++ b/kvision-modules/kvision-tabulator/src/test/kotlin/test/pl/treksoft/kvision/TestUtil.kt
@@ -28,6 +28,8 @@ import pl.treksoft.jquery.get
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.panel.Root
 import kotlinx.browser.document
+import org.w3c.dom.asList
+import pl.treksoft.jquery.JQuery
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -70,8 +72,8 @@ interface DomSpec : TestSpec {
 
     fun assertEqualsHtml(expected: String?, actual: String?, message: String?) {
         if (expected != null && actual != null) {
-            val exp = jQuery(expected)
-            val act = jQuery(actual)
+            val exp = jQuery(expected).normalizeClassListRecursive()
+            val act = jQuery(actual).normalizeClassListRecursive()
             val result = exp[0]?.isEqualNode(act[0])
             if (result == true) {
                 assertTrue(result == true, message)
@@ -82,6 +84,18 @@ interface DomSpec : TestSpec {
             assertEquals(expected, actual, message)
         }
     }
+}
+
+private fun JQuery.normalizeClassList(): JQuery {
+    each { _, elem ->
+        elem.setAttribute("class", elem.classList.asList().sorted().joinToString(" "))
+    }
+    return this
+}
+
+private fun JQuery.normalizeClassListRecursive(): JQuery {
+    jQuery("*", this).addBack().normalizeClassList()
+    return this
 }
 
 interface WSpec : DomSpec {

--- a/kvision-modules/kvision-testutils/src/test/kotlin/pl/treksoft/kvision/test/TestUtil.kt
+++ b/kvision-modules/kvision-testutils/src/test/kotlin/pl/treksoft/kvision/test/TestUtil.kt
@@ -26,6 +26,8 @@ import pl.treksoft.jquery.invoke
 import pl.treksoft.jquery.get
 import pl.treksoft.kvision.panel.Root
 import kotlinx.browser.document
+import org.w3c.dom.asList
+import pl.treksoft.jquery.JQuery
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -70,8 +72,8 @@ interface DomSpec : TestSpec {
 
     fun assertEqualsHtml(expected: String?, actual: String?, message: String?) {
         if (expected != null && actual != null) {
-            val exp = jQuery(expected)
-            val act = jQuery(actual)
+            val exp = jQuery(expected).normalizeClassListRecursive()
+            val act = jQuery(actual).normalizeClassListRecursive()
             val result = exp[0]?.isEqualNode(act[0])
             if (result == true) {
                 assertTrue(result == true, message)
@@ -82,4 +84,16 @@ interface DomSpec : TestSpec {
             assertEquals(expected, actual, message)
         }
     }
+}
+
+private fun JQuery.normalizeClassList(): JQuery {
+    each { _, elem ->
+        elem.setAttribute("class", elem.classList.asList().sorted().joinToString(" "))
+    }
+    return this
+}
+
+private fun JQuery.normalizeClassListRecursive(): JQuery {
+    jQuery("*", this).addBack().normalizeClassList()
+    return this
 }

--- a/src/main/kotlin/pl/treksoft/kvision/core/ClassSetBuilder.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/core/ClassSetBuilder.kt
@@ -5,6 +5,13 @@ package pl.treksoft.kvision.core
  */
 interface ClassSetBuilder {
     fun add(value: String)
+
+    fun add(value: CssClass?) {
+        if (value != null) {
+            add(value.className)
+        }
+    }
+
     fun addAll(values: Collection<String>)
 }
 

--- a/src/main/kotlin/pl/treksoft/kvision/core/ClassSetBuilder.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/core/ClassSetBuilder.kt
@@ -1,0 +1,27 @@
+package pl.treksoft.kvision.core
+
+/**
+ * A builder in order to create a set of CSS-classes
+ */
+interface ClassSetBuilder {
+    fun add(value: String)
+    fun addAll(values: Collection<String>)
+}
+
+internal class ClassSetBuilderImpl : ClassSetBuilder {
+    val classes: Set<String>
+        get() = HashSet(_classes)
+
+    private val _classes: MutableSet<String> = HashSet()
+
+    override fun add(value: String) {
+        _classes.add(value)
+    }
+
+    override fun addAll(values: Collection<String>) {
+        _classes.addAll(values)
+    }
+}
+
+fun buildClassSet(delegate: (builder: ClassSetBuilder) -> Unit): Set<String> =
+    ClassSetBuilderImpl().also { delegate(it) }.classes

--- a/src/main/kotlin/pl/treksoft/kvision/core/CssClass.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/core/CssClass.kt
@@ -1,0 +1,5 @@
+package pl.treksoft.kvision.core
+
+interface CssClass {
+    val className: String
+}

--- a/src/main/kotlin/pl/treksoft/kvision/core/LazyCache.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/core/LazyCache.kt
@@ -1,0 +1,16 @@
+package pl.treksoft.kvision.core
+
+/**
+ * A cache that behaves like a resettable `Lazy`: It generates a value from a given initializer lazily, however that
+ * cache can be cleared, so that the value will be regenerated when queried next
+ */
+class LazyCache<T : Any>(val initializer: () -> T) {
+    val value: T
+        get() = _value ?: initializer().also { _value = it }
+
+    private var _value: T? = null
+
+    fun clear() {
+        _value = null
+    }
+}

--- a/src/main/kotlin/pl/treksoft/kvision/form/FormControl.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/form/FormControl.kt
@@ -23,13 +23,14 @@ package pl.treksoft.kvision.form
 
 import org.w3c.files.File
 import pl.treksoft.kvision.core.Component
+import pl.treksoft.kvision.core.CssClass
 import pl.treksoft.kvision.types.KFile
 import kotlin.js.Date
 
 /**
  * Input controls sizes.
  */
-enum class InputSize(val className: String) {
+enum class InputSize(override val className: String) : CssClass {
     LARGE("form-control-lg"),
     SMALL("form-control-sm")
 }
@@ -37,7 +38,7 @@ enum class InputSize(val className: String) {
 /**
  * Input controls validation status.
  */
-enum class ValidationStatus(val className: String) {
+enum class ValidationStatus(override val className: String) : CssClass {
     VALID("is-valid"),
     INVALID("is-invalid")
 }

--- a/src/main/kotlin/pl/treksoft/kvision/form/FormPanel.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/form/FormPanel.kt
@@ -24,8 +24,8 @@ package pl.treksoft.kvision.form
 import com.github.snabbdom.VNode
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.serializer
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringBoolPair
 import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.form.FormPanel.Companion.create
 import pl.treksoft.kvision.html.Div
@@ -210,14 +210,13 @@ open class FormPanel<K : Any>(
         return render("form", childrenVNodes())
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
         if (type != null) {
-            cl.add(type.formType to true)
-            if (type == FormType.HORIZONTAL) cl.add("container-fluid" to true)
+            classSetBuilder.add(type.formType)
+            if (type == FormType.HORIZONTAL) classSetBuilder.add("container-fluid")
         }
-        if (condensed) cl.add("kv-form-condensed" to true)
-        return cl
+        if (condensed) classSetBuilder.add("kv-form-condensed")
     }
 
     override fun getSnAttrs(): List<StringPair> {

--- a/src/main/kotlin/pl/treksoft/kvision/form/check/CheckBox.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/form/check/CheckBox.kt
@@ -22,8 +22,9 @@
 package pl.treksoft.kvision.form.check
 
 import org.w3c.dom.events.MouseEvent
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringBoolPair
+import pl.treksoft.kvision.core.CssClass
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.form.BoolFormControl
 import pl.treksoft.kvision.form.FieldLabel
@@ -37,7 +38,7 @@ import pl.treksoft.kvision.utils.SnOn
 /**
  * Checkbox style options.
  */
-enum class CheckBoxStyle(internal val className: String) {
+enum class CheckBoxStyle(override val className: String) : CssClass {
     PRIMARY("abc-checkbox-primary"),
     SUCCESS("abc-checkbox-success"),
     INFO("abc-checkbox-info"),
@@ -145,21 +146,18 @@ open class CheckBox(
         return this
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
-        style?.let {
-            cl.add(it.className to true)
-        }
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
+        classSetBuilder.add(style)
         if (circled) {
-            cl.add("abc-checkbox-circle" to true)
+            classSetBuilder.add("abc-checkbox-circle")
         }
         if (inline) {
-            cl.add("form-check-inline" to true)
+            classSetBuilder.add("form-check-inline")
         }
         if (validatorError != null) {
-            cl.add("text-danger" to true)
+            classSetBuilder.add("text-danger")
         }
-        return cl
     }
 
     /**

--- a/src/main/kotlin/pl/treksoft/kvision/form/check/CheckInput.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/form/check/CheckInput.kt
@@ -23,7 +23,7 @@ package pl.treksoft.kvision.form.check
 
 import com.github.snabbdom.VNode
 import org.w3c.dom.events.MouseEvent
-import pl.treksoft.kvision.core.StringBoolPair
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.form.FormInput
@@ -114,15 +114,10 @@ abstract class CheckInput(
         return render("input")
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
-        validationStatus?.let {
-            cl.add(it.className to true)
-        }
-        size?.let {
-            cl.add(it.className to true)
-        }
-        return cl
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
+        classSetBuilder.add(validationStatus)
+        classSetBuilder.add(size)
     }
 
     override fun getSnAttrs(): List<StringPair> {

--- a/src/main/kotlin/pl/treksoft/kvision/form/check/Radio.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/form/check/Radio.kt
@@ -22,8 +22,9 @@
 package pl.treksoft.kvision.form.check
 
 import org.w3c.dom.events.MouseEvent
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringBoolPair
+import pl.treksoft.kvision.core.CssClass
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.form.BoolFormControl
 import pl.treksoft.kvision.form.FieldLabel
@@ -37,7 +38,7 @@ import pl.treksoft.kvision.utils.SnOn
 /**
  * Radio style options.
  */
-enum class RadioStyle(internal val className: String) {
+enum class RadioStyle(override val className: String) : CssClass {
     PRIMARY("abc-radio-primary"),
     SUCCESS("abc-radio-success"),
     INFO("abc-radio-info"),
@@ -156,26 +157,23 @@ open class Radio(
         return this
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
         if (!squared) {
-            cl.add("abc-radio" to true)
-            style?.let {
-                cl.add(it.className to true)
-            }
+            classSetBuilder.add("abc-radio")
+            classSetBuilder.add(style)
         } else {
-            cl.add("abc-checkbox" to true)
+            classSetBuilder.add("abc-checkbox")
             style?.let {
-                cl.add(it.className.replace("radio", "checkbox") to true)
+                classSetBuilder.add(it.className.replace("radio", "checkbox"))
             }
         }
         if (inline) {
-            cl.add("form-check-inline" to true)
+            classSetBuilder.add("form-check-inline")
         }
         if (validatorError != null) {
-            cl.add("text-danger" to true)
+            classSetBuilder.add("text-danger")
         }
-        return cl
     }
 
     /**

--- a/src/main/kotlin/pl/treksoft/kvision/form/check/RadioGroup.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/form/check/RadioGroup.kt
@@ -21,9 +21,9 @@
  */
 package pl.treksoft.kvision.form.check
 
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Component
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringBoolPair
 import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.form.FieldLabel
 import pl.treksoft.kvision.form.FormHorizontalRatio
@@ -147,17 +147,16 @@ open class RadioGroup(
         counter++
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
         if (validatorError != null) {
-            cl.add("text-danger" to true)
+            classSetBuilder.add("text-danger")
         }
         if (inline) {
-            cl.add("kv-radiogroup-inline" to true)
+            classSetBuilder.add("kv-radiogroup-inline")
         } else {
-            cl.add("kv-radiogroup" to true)
+            classSetBuilder.add("kv-radiogroup")
         }
-        return cl
     }
 
     private fun setValueToChildren(value: String?) {

--- a/src/main/kotlin/pl/treksoft/kvision/form/check/RadioGroupInput.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/form/check/RadioGroupInput.kt
@@ -21,9 +21,9 @@
  */
 package pl.treksoft.kvision.form.check
 
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Component
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringBoolPair
 import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.form.FormInput
 import pl.treksoft.kvision.form.InputSize
@@ -102,14 +102,13 @@ open class RadioGroupInput(
         counter++
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
         if (inline) {
-            cl.add("kv-radiogroup-inline" to true)
+            classSetBuilder.add("kv-radiogroup-inline")
         } else {
-            cl.add("kv-radiogroup" to true)
+            classSetBuilder.add("kv-radiogroup")
         }
-        return cl
     }
 
     private fun setValueToChildren(value: String?) {

--- a/src/main/kotlin/pl/treksoft/kvision/form/range/Range.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/form/range/Range.kt
@@ -21,8 +21,8 @@
  */
 package pl.treksoft.kvision.form.range
 
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringBoolPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.form.FieldLabel
 import pl.treksoft.kvision.form.FormHorizontalRatio
@@ -162,12 +162,11 @@ open class Range(
         counter++
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
         if (validatorError != null) {
-            cl.add("text-danger" to true)
+            classSetBuilder.add("text-danger")
         }
-        return cl
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/src/main/kotlin/pl/treksoft/kvision/form/range/RangeInput.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/form/range/RangeInput.kt
@@ -23,8 +23,8 @@ package pl.treksoft.kvision.form.range
 
 import com.github.snabbdom.VNode
 import org.w3c.dom.HTMLInputElement
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringBoolPair
 import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.form.FormInput
@@ -123,15 +123,10 @@ open class RangeInput(
         return render("input")
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
-        validationStatus?.let {
-            cl.add(it.className to true)
-        }
-        size?.let {
-            cl.add(it.className to true)
-        }
-        return cl
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
+        classSetBuilder.add(validationStatus)
+        classSetBuilder.add(size)
     }
 
     override fun getSnAttrs(): List<StringPair> {

--- a/src/main/kotlin/pl/treksoft/kvision/form/select/SimpleSelect.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/form/select/SimpleSelect.kt
@@ -21,9 +21,9 @@
  */
 package pl.treksoft.kvision.form.select
 
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Component
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringBoolPair
 import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.form.FieldLabel
@@ -167,12 +167,11 @@ open class SimpleSelect(
         counter++
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
         if (validatorError != null) {
-            cl.add("text-danger" to true)
+            classSetBuilder.add("text-danger")
         }
-        return cl
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/src/main/kotlin/pl/treksoft/kvision/form/select/SimpleSelectInput.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/form/select/SimpleSelectInput.kt
@@ -22,8 +22,8 @@
 package pl.treksoft.kvision.form.select
 
 import com.github.snabbdom.VNode
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringBoolPair
 import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.form.FormInput
 import pl.treksoft.kvision.form.InputSize
@@ -200,15 +200,10 @@ open class SimpleSelectInput(
         }
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
-        validationStatus?.let {
-            cl.add(it.className to true)
-        }
-        size?.let {
-            cl.add(it.className to true)
-        }
-        return cl
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
+        classSetBuilder.add(validationStatus)
+        classSetBuilder.add(size)
     }
 
     override fun getSnAttrs(): List<StringPair> {

--- a/src/main/kotlin/pl/treksoft/kvision/form/text/AbstractText.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/form/text/AbstractText.kt
@@ -21,7 +21,7 @@
  */
 package pl.treksoft.kvision.form.text
 
-import pl.treksoft.kvision.core.StringBoolPair
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.form.FieldLabel
 import pl.treksoft.kvision.form.InvalidFeedback
@@ -136,12 +136,11 @@ abstract class AbstractText(label: String? = null, rich: Boolean = false, classe
         internal var counter = 0
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
         if (validatorError != null) {
-            cl.add("text-danger" to true)
+            classSetBuilder.add("text-danger")
         }
-        return cl
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/src/main/kotlin/pl/treksoft/kvision/form/text/AbstractTextInput.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/form/text/AbstractTextInput.kt
@@ -22,7 +22,7 @@
 package pl.treksoft.kvision.form.text
 
 import com.github.snabbdom.VNode
-import pl.treksoft.kvision.core.StringBoolPair
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.form.FormInput
@@ -105,15 +105,10 @@ abstract class AbstractTextInput(
      */
     override var validationStatus: ValidationStatus? by refreshOnUpdate()
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
-        validationStatus?.let {
-            cl.add(it.className to true)
-        }
-        size?.let {
-            cl.add(it.className to true)
-        }
-        return cl
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
+        classSetBuilder.add(validationStatus)
+        classSetBuilder.add(size)
     }
 
     override fun getSnAttrs(): List<StringPair> {

--- a/src/main/kotlin/pl/treksoft/kvision/html/Button.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/html/Button.kt
@@ -23,9 +23,10 @@ package pl.treksoft.kvision.html
 
 import com.github.snabbdom.VNode
 import org.w3c.dom.events.MouseEvent
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Container
+import pl.treksoft.kvision.core.CssClass
 import pl.treksoft.kvision.core.ResString
-import pl.treksoft.kvision.core.StringBoolPair
 import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.panel.SimplePanel
 import pl.treksoft.kvision.state.ObservableState
@@ -35,7 +36,7 @@ import pl.treksoft.kvision.utils.set
 /**
  * Button styles.
  */
-enum class ButtonStyle(val className: String) {
+enum class ButtonStyle(override val className: String) : CssClass {
     PRIMARY("btn-primary"),
     SECONDARY("btn-secondary"),
     SUCCESS("btn-success"),
@@ -58,7 +59,7 @@ enum class ButtonStyle(val className: String) {
 /**
  * Button sizes.
  */
-enum class ButtonSize(internal val className: String) {
+enum class ButtonSize(override val className: String) : CssClass {
     LARGE("btn-lg"),
     SMALL("btn-sm")
 }
@@ -149,17 +150,14 @@ open class Button(
         }
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
-        cl.add("btn" to true)
-        cl.add(style.className to true)
-        size?.let {
-            cl.add(it.className to true)
-        }
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
+        classSetBuilder.add("btn")
+        classSetBuilder.add(style)
+        classSetBuilder.add(size)
         if (block) {
-            cl.add("btn-block" to true)
+            classSetBuilder.add("btn-block")
         }
-        return cl
     }
 
     override fun getSnAttrs(): List<StringPair> {

--- a/src/main/kotlin/pl/treksoft/kvision/html/Icon.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/html/Icon.kt
@@ -21,8 +21,8 @@
  */
 package pl.treksoft.kvision.html
 
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringBoolPair
 import pl.treksoft.kvision.state.ObservableState
 import pl.treksoft.kvision.state.bind
 
@@ -39,10 +39,9 @@ open class Icon(icon: String) : Tag(TAG.SPAN) {
      */
     var icon by refreshOnUpdate(icon)
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
-        icon.split(" ").forEach { cl.add(it to true) }
-        return cl
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
+        classSetBuilder.addAll(icon.split(" "))
     }
 }
 

--- a/src/main/kotlin/pl/treksoft/kvision/html/Image.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/html/Image.kt
@@ -22,9 +22,10 @@
 package pl.treksoft.kvision.html
 
 import com.github.snabbdom.VNode
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Container
+import pl.treksoft.kvision.core.CssClass
 import pl.treksoft.kvision.core.ResString
-import pl.treksoft.kvision.core.StringBoolPair
 import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.state.ObservableState
@@ -34,7 +35,7 @@ import pl.treksoft.kvision.utils.set
 /**
  * Image shapes.
  */
-enum class ImageShape(internal val className: String) {
+enum class ImageShape(override val className: String) : CssClass {
     ROUNDED("rounded"),
     CIRCLE("rounded-circle"),
     THUMBNAIL("img-thumbnail")
@@ -95,18 +96,15 @@ open class Image(
         return pr
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
         if (responsive) {
-            cl.add("img-fluid" to true)
+            classSetBuilder.add("img-fluid")
         }
         if (centered) {
-            cl.add("center-block" to true)
+            classSetBuilder.add("center-block")
         }
-        shape?.let {
-            cl.add(it.className to true)
-        }
-        return cl
+        classSetBuilder.add(shape)
     }
 }
 

--- a/src/main/kotlin/pl/treksoft/kvision/html/ListTag.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/html/ListTag.kt
@@ -24,9 +24,9 @@ package pl.treksoft.kvision.html
 import com.github.snabbdom.VNode
 import com.github.snabbdom.h
 import pl.treksoft.kvision.KVManager
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Component
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringBoolPair
 import pl.treksoft.kvision.panel.SimplePanel
 import pl.treksoft.kvision.state.ObservableState
 import pl.treksoft.kvision.state.bind
@@ -144,15 +144,14 @@ open class ListTag(
         }
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
         @Suppress("NON_EXHAUSTIVE_WHEN")
         when (type) {
-            ListType.UNSTYLED -> cl.add("list-unstyled" to true)
-            ListType.INLINE -> cl.add("list-inline" to true)
-            ListType.DL_HORIZ -> cl.add("dl-horizontal" to true)
+            ListType.UNSTYLED -> classSetBuilder.add("list-unstyled")
+            ListType.INLINE -> classSetBuilder.add("list-inline")
+            ListType.DL_HORIZ -> classSetBuilder.add("dl-horizontal")
         }
-        return cl
     }
 }
 

--- a/src/main/kotlin/pl/treksoft/kvision/html/Tag.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/html/Tag.kt
@@ -23,8 +23,9 @@ package pl.treksoft.kvision.html
 
 import com.github.snabbdom.VNode
 import pl.treksoft.kvision.KVManager
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringBoolPair
+import pl.treksoft.kvision.core.CssClass
 import pl.treksoft.kvision.i18n.I18n
 import pl.treksoft.kvision.panel.SimplePanel
 import pl.treksoft.kvision.state.ObservableState
@@ -106,7 +107,7 @@ enum class TAG(internal val tagName: String) {
 /**
  * CSS align attributes.
  */
-enum class Align(val className: String) {
+enum class Align(override val className: String) : CssClass {
     LEFT("text-left"),
     CENTER("text-center"),
     RIGHT("text-right"),
@@ -195,12 +196,9 @@ open class Tag(
         }
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
-        align?.let {
-            cl.add(it.className to true)
-        }
-        return cl
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
+        classSetBuilder.add(align)
     }
 
     override operator fun String.unaryPlus() {

--- a/src/main/kotlin/pl/treksoft/kvision/panel/Root.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/panel/Root.kt
@@ -23,15 +23,15 @@ package pl.treksoft.kvision.panel
 
 import com.github.snabbdom.VNode
 import com.github.snabbdom.h
+import kotlinx.browser.document
 import org.w3c.dom.HTMLElement
 import pl.treksoft.kvision.Application
 import pl.treksoft.kvision.KVManager
-import pl.treksoft.kvision.core.StringBoolPair
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Style
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.utils.snClasses
 import pl.treksoft.kvision.utils.snOpt
-import kotlinx.browser.document
 
 /**
  * Root container types.
@@ -201,13 +201,11 @@ class Root : SimplePanel {
         return contextMenus.filter { it.visible }.map { it.renderVNode() }.toTypedArray()
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        return if (containerType == ContainerType.NONE) {
-            super.getSnClass()
-        } else {
-            super.getSnClass() + (containerType.type to true)
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
+        if (containerType != ContainerType.NONE) {
+            classSetBuilder.add(containerType.type)
         }
-
     }
 
     internal fun reRender(): Root {

--- a/src/main/kotlin/pl/treksoft/kvision/table/Table.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/table/Table.kt
@@ -23,9 +23,9 @@ package pl.treksoft.kvision.table
 
 import com.github.snabbdom.VNode
 import com.github.snabbdom.h
+import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Component
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringBoolPair
 import pl.treksoft.kvision.html.TAG
 import pl.treksoft.kvision.html.Tag
 import pl.treksoft.kvision.panel.SimplePanel
@@ -175,12 +175,11 @@ open class Table(
         return listOf(captionElement, thead, tbody).mapNotNull { it?.renderVNode() }.toTypedArray()
     }
 
-    override fun getSnClass(): List<StringBoolPair> {
-        val cl = super.getSnClass().toMutableList()
+    override fun buildClassSet(classSetBuilder: ClassSetBuilder) {
+        super.buildClassSet(classSetBuilder)
         types.forEach {
-            cl.add(it.type to true)
+            classSetBuilder.add(it.type)
         }
-        return cl
     }
 
     override fun add(child: Component): SimplePanel {

--- a/src/main/kotlin/pl/treksoft/kvision/utils/Snabbdom.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/utils/Snabbdom.kt
@@ -300,6 +300,16 @@ inline fun snClasses(pairs: List<StringBoolPair>): Classes {
 }
 
 /**
+ * Helper function for creating classes parameters for Snabbdom.
+ */
+@Suppress("UnsafeCastFromDynamic", "NOTHING_TO_INLINE")
+inline fun snClasses(classes: Iterable<String>): Classes {
+    return obj {
+        classes.forEach { this[it] = true }
+    }
+}
+
+/**
  * Helper function for creating attributes parameters for Snabbdom.
  */
 @Suppress("UnsafeCastFromDynamic", "NOTHING_TO_INLINE")

--- a/src/test/kotlin/test/pl/treksoft/kvision/TestUtil.kt
+++ b/src/test/kotlin/test/pl/treksoft/kvision/TestUtil.kt
@@ -23,6 +23,8 @@ package test.pl.treksoft.kvision
 
 import kotlinx.browser.document
 import org.w3c.dom.Element
+import org.w3c.dom.asList
+import pl.treksoft.jquery.JQuery
 import pl.treksoft.jquery.jQuery
 import pl.treksoft.jquery.invoke
 import pl.treksoft.jquery.get
@@ -70,8 +72,8 @@ interface DomSpec : TestSpec {
 
     fun assertEqualsHtml(expected: String?, actual: String?, message: String?) {
         if (expected != null && actual != null) {
-            val exp = jQuery(expected)
-            val act = jQuery(actual)
+            val exp = jQuery(expected).normalizeClassListRecursive()
+            val act = jQuery(actual).normalizeClassListRecursive()
             val result = exp[0]?.isEqualNode(act[0])
             if (result == true) {
                 assertTrue(result == true, message)
@@ -82,6 +84,18 @@ interface DomSpec : TestSpec {
             assertEquals(expected, actual, message)
         }
     }
+}
+
+private fun JQuery.normalizeClassList(): JQuery {
+    each { _, elem ->
+        elem.setAttribute("class", elem.classList.asList().sorted().joinToString(" "))
+    }
+    return this
+}
+
+private fun JQuery.normalizeClassListRecursive(): JQuery {
+    jQuery("*", this).addBack().normalizeClassList()
+    return this
 }
 
 interface WSpec : DomSpec {

--- a/src/test/kotlin/test/pl/treksoft/kvision/core/ClassSetBuilderImplSpec.kt
+++ b/src/test/kotlin/test/pl/treksoft/kvision/core/ClassSetBuilderImplSpec.kt
@@ -1,0 +1,54 @@
+package test.pl.treksoft.kvision.core
+
+import pl.treksoft.kvision.core.ClassSetBuilderImpl
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ClassSetBuilderImplSpec {
+    @Test
+    fun addNothing_returnsEmptySet() {
+        // execution
+        val actual = ClassSetBuilderImpl().classes
+
+        // evaluation
+        assertEquals(actual.sorted().joinToString(), "")
+    }
+
+    @Test
+    fun add_addsValueToSet() {
+        // execution
+        val actual = ClassSetBuilderImpl().also {
+            it.add("value1")
+            it.add("value2")
+        }.classes
+
+        // evaluation
+        assertEquals("value1,value2", actual.sorted().joinToString(","))
+    }
+
+    @Test
+    fun addAll_addsValuesToSet() {
+        // execution
+        val actual = ClassSetBuilderImpl().also {
+            it.addAll(listOf("value1", "value2"))
+        }.classes
+
+        // evaluation
+        assertEquals("value1,value2", actual.sorted().joinToString(","))
+    }
+
+    @Test
+    fun addAfterQueryingValue_doesNotChanceValue() {
+        // setup
+        val builder = ClassSetBuilderImpl()
+        builder.add("value1")
+
+        // execution
+        val actual = builder.classes
+        builder.add("value2")
+
+        // evaluation
+        assertEquals("value1", actual.sorted().joinToString(","))
+    }
+}

--- a/src/test/kotlin/test/pl/treksoft/kvision/core/LazyCacheSpec.kt
+++ b/src/test/kotlin/test/pl/treksoft/kvision/core/LazyCacheSpec.kt
@@ -1,0 +1,68 @@
+package test.pl.treksoft.kvision.core
+
+import pl.treksoft.kvision.core.LazyCache
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class LazyCacheSpec {
+    private var invocationCount = 0
+    private lateinit var lazyCache: LazyCache<Int>
+
+    @BeforeTest
+    fun setUp() {
+        invocationCount = 0
+        lazyCache = LazyCache { invocationCount++ + 10 }
+    }
+
+    @Test
+    fun doesNotGenerateValueIfNotQueried() {
+        // execution performed by setUp
+        // evaluation
+        assertEquals(0, invocationCount, "invocation count")
+    }
+
+    @Test
+    fun generatesValueIfQueried() {
+        // execution
+        val value = lazyCache.value
+
+        // evaluation
+        assertEquals(value, 10, "returned value")
+        assertEquals(invocationCount, 1, "invocation count")
+    }
+
+    @Test
+    fun doesNotRegenerateValueIfQueriedTwice() {
+        // execution
+        val value1 = lazyCache.value
+        val value2 = lazyCache.value
+
+        // evaluation
+        assertEquals(value1, 10, "returned value 1")
+        assertEquals(value2, 10, "returned value 2")
+        assertEquals(invocationCount, 1, "invocation count")
+    }
+
+    @Test
+    fun regeneratesValueIfClearedBeforeRead() {
+        // execution
+        val value1 = lazyCache.value
+        lazyCache.clear()
+        val value2 = lazyCache.value
+
+        // evaluation
+        assertEquals(value1, 10, "returned value 1")
+        assertEquals(value2, 11, "returned value 2")
+        assertEquals(invocationCount, 2, "invocation count")
+    }
+
+    @Test
+    fun clear_doesNotGenerateNewValue() {
+        // execution
+        lazyCache.clear()
+
+        // evaluation
+        assertEquals(invocationCount, 0, "invocation count")
+    }
+}


### PR DESCRIPTION
Follow up from the discussion in #196:

The current method `getSnClass` uses `List<Pair<String, Boolean>>` to represent a set of classes. This is because Snapdom has the [API for classes](https://github.com/snabbdom/snabbdom#the-class-module) designed like that. However actually a `Set<String>` would be easier to use, needs less code and should be a little more intuitive. Also the due to the usage of an immutable `List` by the API there is a lot of copying of the list going on, when the `getSnClass` calls bubble through the class hierarchy.

This PR has these goals:
- Simplify the API (just use a set of strings)
- Increase extensibility (encapsulating data in a custom builder interface)
- Improve performance (use a builder instead of a list) (probably neglectable, but nevertheless)

Edit: One thing I noticed while editing: `DropDownButton`: If `forNavbar` is set, there is no call to super. Is this intended?