### PR TITLE
Refactor: Use `addAfterDisposeHook` to unsubscribe from observables automatically

### DIFF
--- a/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/progress/NumberProgressBarTag.kt
+++ b/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/progress/NumberProgressBarTag.kt
@@ -47,10 +47,8 @@ class NumberProgressBarTag(
             update()
         }
 
-    private val unsubscribe: () -> Unit
-
     init {
-        unsubscribe = progress.bounds.subscribe { update() }
+        addAfterDisposeHook(progress.bounds.subscribe { update() })
         update()
     }
 
@@ -62,11 +60,6 @@ class NumberProgressBarTag(
         ariaMin = bounds.min.toString()
         ariaValue = value.toString()
         contentGenerator.generateContent(this, value, bounds)
-    }
-
-    override fun dispose() {
-        super.dispose()
-        unsubscribe()
     }
 }
 

--- a/src/main/kotlin/pl/treksoft/kvision/state/StateBinding.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/state/StateBinding.kt
@@ -41,10 +41,8 @@ class StateBinding<S : Any, CONT : Container, CONTENT>(
     private val factory: (CONT.(S) -> CONTENT)
 ) : Widget(setOf()) {
 
-    private val unsubscribe: () -> Unit
-
     init {
-        unsubscribe = observableState.subscribe { update(it) }
+        addAfterDisposeHook(observableState.subscribe(this::update))
     }
 
     private var updateState: ((S, CONTENT) -> Unit)? = null
@@ -70,11 +68,6 @@ class StateBinding<S : Any, CONT : Container, CONTENT>(
 
     internal fun setUpdateState(updateState: (S, CONTENT) -> Unit) {
         this.updateState = updateState
-    }
-
-    override fun dispose() {
-        unsubscribe()
-        super.dispose()
     }
 }
 


### PR DESCRIPTION
Since #197 it is possible now to get rid of an instance variable which is only held to unsubscribe on disposal, by instead using `addAfterDisposeHook`.