### PR TITLE
Refactor getSnAttrs: Replace it with a method that uses a builder instead

### DIFF
--- a/kvision-modules/kvision-bootstrap-select/src/main/kotlin/pl/treksoft/kvision/form/select/SelectInput.kt
+++ b/kvision-modules/kvision-bootstrap-select/src/main/kotlin/pl/treksoft/kvision/form/select/SelectInput.kt
@@ -23,6 +23,7 @@ package pl.treksoft.kvision.form.select
 
 import com.github.snabbdom.VNode
 import pl.treksoft.kvision.KVManagerSelect.KVNULL
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Component
 import pl.treksoft.kvision.core.Container
@@ -296,59 +297,54 @@ open class SelectInput(
     }
 
     @Suppress("ComplexMethod")
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         name?.let {
-            sn.add("name" to it)
+            attributeSetBuilder.add("name", it)
         }
         if (multiple) {
-            sn.add("multiple" to "multiple")
+            attributeSetBuilder.add("multiple")
         }
         maxOptions?.let {
-            sn.add("data-max-options" to "" + it)
+            attributeSetBuilder.add("data-max-options", "" + it)
         }
         if (liveSearch) {
-            sn.add("data-live-search" to "true")
+            attributeSetBuilder.add("data-live-search", "true")
         }
         placeholder?.let {
-            sn.add("title" to translate(it))
+            attributeSetBuilder.add("title", translate(it))
         }
-        autofocus?.let {
-            if (it) {
-                sn.add("autofocus" to "autofocus")
-            }
+        if (autofocus == true) {
+            attributeSetBuilder.add("autofocus")
         }
         if (disabled) {
-            sn.add("disabled" to "disabled")
+            attributeSetBuilder.add("disabled")
         }
         val btnStyle = style?.className ?: "btn-default"
-        when (size) {
-            InputSize.LARGE -> {
-                sn.add("data-style" to "$btnStyle btn-lg")
+        attributeSetBuilder.add(
+            "data-style",
+            when (size) {
+                InputSize.LARGE -> "$btnStyle btn-lg"
+                InputSize.SMALL -> "$btnStyle btn-sm"
+                else -> btnStyle
             }
-            InputSize.SMALL -> {
-                sn.add("data-style" to "$btnStyle btn-sm")
-            }
-            else -> {
-                sn.add("data-style" to btnStyle)
-            }
-        }
+        )
+
         selectWidthType?.let {
-            sn.add("data-width" to it.value)
+            attributeSetBuilder.add("data-width", it.value)
         } ?: selectWidth?.let {
-            sn.add("data-width" to it.asString())
+            attributeSetBuilder.add("data-width", it.asString())
         }
         when (dropdownAlign) {
             SelectDropdownAlign.RIGHT -> {
-                sn.add("data-dropdown-align-right" to "true")
+                attributeSetBuilder.add("data-dropdown-align-right", "true")
             }
             SelectDropdownAlign.AUTO -> {
-                sn.add("data-dropdown-align-right" to "auto")
+                attributeSetBuilder.add("data-dropdown-align-right", "auto")
             }
             else -> {
             }
         }
-        return sn
     }
 
     @Suppress("UnsafeCastFromDynamic")

--- a/kvision-modules/kvision-bootstrap-select/src/main/kotlin/pl/treksoft/kvision/form/select/SelectOptGroup.kt
+++ b/kvision-modules/kvision-bootstrap-select/src/main/kotlin/pl/treksoft/kvision/form/select/SelectOptGroup.kt
@@ -22,6 +22,7 @@
 package pl.treksoft.kvision.form.select
 
 import com.github.snabbdom.VNode
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.panel.SimplePanel
 import pl.treksoft.kvision.utils.set
@@ -81,16 +82,15 @@ open class SelectOptGroup(
         }
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
-        sn.add("label" to translate(label))
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
+        attributeSetBuilder.add("label", translate(label))
         maxOptions?.let {
-            sn.add("data-max-options" to "" + it)
+            attributeSetBuilder.add("data-max-options", "" + it)
         }
         if (disabled) {
-            sn.add("disabled" to "disabled")
+            attributeSetBuilder.add("disabled")
         }
-        return sn
     }
 }
 

--- a/kvision-modules/kvision-bootstrap-select/src/main/kotlin/pl/treksoft/kvision/form/select/SelectOption.kt
+++ b/kvision-modules/kvision-bootstrap-select/src/main/kotlin/pl/treksoft/kvision/form/select/SelectOption.kt
@@ -22,7 +22,7 @@
 package pl.treksoft.kvision.form.select
 
 import com.github.snabbdom.VNode
-import pl.treksoft.kvision.core.StringPair
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.utils.set
 
@@ -88,28 +88,27 @@ open class SelectOption(
     }
 
     @Suppress("ComplexMethod")
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         if (!divider) {
             value?.let {
-                sn.add("value" to it)
+                attributeSetBuilder.add("value", it)
             }
             subtext?.let {
-                sn.add("data-subtext" to translate(it))
+                attributeSetBuilder.add("data-subtext", translate(it))
             }
             icon?.let {
-                sn.add("data-icon" to it)
+                attributeSetBuilder.add("data-icon", it)
             }
             if (disabled) {
-                sn.add("disabled" to "disabled")
+                attributeSetBuilder.add("disabled")
             }
             if (selected) {
-                sn.add("selected" to "selected")
+                attributeSetBuilder.add("selected")
             }
         } else {
-            sn.add("data-divider" to "true")
+            attributeSetBuilder.add("data-divider", "true")
         }
-        return sn
     }
 }
 

--- a/kvision-modules/kvision-bootstrap-select/src/test/kotlin/test/pl/treksoft/kvision/TestUtil.kt
+++ b/kvision-modules/kvision-bootstrap-select/src/test/kotlin/test/pl/treksoft/kvision/TestUtil.kt
@@ -21,15 +21,16 @@
  */
 package test.pl.treksoft.kvision
 
-import org.w3c.dom.Element
-import pl.treksoft.jquery.jQuery
-import pl.treksoft.jquery.invoke
-import pl.treksoft.jquery.get
-import pl.treksoft.kvision.core.Widget
-import pl.treksoft.kvision.panel.Root
 import kotlinx.browser.document
+import org.w3c.dom.Element
+import org.w3c.dom.Node
 import org.w3c.dom.asList
 import pl.treksoft.jquery.JQuery
+import pl.treksoft.jquery.get
+import pl.treksoft.jquery.invoke
+import pl.treksoft.jquery.jQuery
+import pl.treksoft.kvision.core.Widget
+import pl.treksoft.kvision.panel.Root
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -111,6 +112,16 @@ interface WSpec : DomSpec {
         }
     }
 
+}
+
+fun removeAllAfter(referenceElement: Node) {
+    var element = referenceElement
+    while(true) {
+        while(element.nextSibling?.also { it.parentNode?.removeChild(it) } != null) {
+            // intentionally blank
+        }
+        element = element.parentNode ?: return
+    }
 }
 
 external fun require(name: String): dynamic

--- a/kvision-modules/kvision-bootstrap-select/src/test/kotlin/test/pl/treksoft/kvision/form/select/SelectInputSpec.kt
+++ b/kvision-modules/kvision-bootstrap-select/src/test/kotlin/test/pl/treksoft/kvision/form/select/SelectInputSpec.kt
@@ -21,13 +21,13 @@
  */
 package test.pl.treksoft.kvision.form.select
 
+import kotlinx.browser.document
 import pl.treksoft.kvision.form.select.SelectInput
 import pl.treksoft.kvision.form.select.SelectWidthType
 import pl.treksoft.kvision.panel.Root
 import test.pl.treksoft.kvision.DomSpec
-import kotlinx.browser.document
+import test.pl.treksoft.kvision.removeAllAfter
 import kotlin.test.Test
-import kotlin.test.assertTrue
 
 class SelectInputSpec : DomSpec {
 
@@ -42,12 +42,13 @@ class SelectInputSpec : DomSpec {
                 emptyOption = true
             }
             root.add(selectInput)
+            removeAllAfter(requireNotNull(document.querySelector("select")))
             val element = document.getElementById("test")
-            assertTrue(
-                true == element?.innerHTML?.startsWith("<div class=\"dropdown bootstrap-select show-tick fit-width\"><select class=\"selectpicker\" multiple=\"multiple\" data-live-search=\"true\" title=\"Choose ...\" data-style=\"btn-default\" data-width=\"fit\"><option value=\"#kvnull\"></option><option value=\"test1\">Test 1</option><option value=\"test2\">Test 2</option></select>"),
+            assertEqualsHtml(
+                """<div class="dropdown bootstrap-select show-tick fit-width"><select class="selectpicker" multiple="multiple" data-live-search="true" title="Choose ..." data-style="btn-default" data-width="fit"><option value="#kvnull"></option><option value="test1">Test 1</option><option value="test2">Test 2</option></select>""",
+                element?.innerHTML,
                 "Should render correct select input"
             )
         }
     }
-
 }

--- a/kvision-modules/kvision-bootstrap-select/src/test/kotlin/test/pl/treksoft/kvision/form/select/SelectSpec.kt
+++ b/kvision-modules/kvision-bootstrap-select/src/test/kotlin/test/pl/treksoft/kvision/form/select/SelectSpec.kt
@@ -21,16 +21,16 @@
  */
 package test.pl.treksoft.kvision.form.select
 
-import pl.treksoft.kvision.panel.Root
-import pl.treksoft.kvision.form.select.SelectWidthType
-import pl.treksoft.kvision.form.select.Select
-import test.pl.treksoft.kvision.DomSpec
 import kotlinx.browser.document
+import pl.treksoft.kvision.form.select.Select
+import pl.treksoft.kvision.form.select.SelectWidthType
+import pl.treksoft.kvision.panel.Root
+import test.pl.treksoft.kvision.DomSpec
+import test.pl.treksoft.kvision.removeAllAfter
 import kotlin.test.Test
-import kotlin.test.assertTrue
+
 
 class SelectSpec : DomSpec {
-
     @Test
     fun render() {
         run {
@@ -42,13 +42,24 @@ class SelectSpec : DomSpec {
                 emptyOption = true
             }
             root.add(select)
-            val element = document.getElementById("test")
+            removeAllAfter(requireNotNull(document.querySelector("select")))
+
             val id = select.input.id
-            assertTrue(
-                true == element?.innerHTML?.startsWith("<div class=\"form-group\"><label class=\"control-label\" for=\"$id\">Label</label><div class=\"dropdown bootstrap-select show-tick form-control fit-width\"><select class=\"form-control selectpicker\" id=\"$id\" multiple=\"multiple\" data-live-search=\"true\" title=\"Choose ...\" data-style=\"btn-default\" data-width=\"fit\"><option value=\"#kvnull\"></option><option value=\"test1\">Test 1</option><option value=\"test2\">Test 2</option></select>"),
+            assertEqualsHtml(
+                """
+                <div class="form-group">
+                    <label class="control-label" for="$id">Label</label>
+                    <div class="dropdown bootstrap-select show-tick form-control fit-width">
+                        <select class="form-control selectpicker" id="$id" multiple="multiple" data-live-search="true" title="Choose ..." data-style="btn-default" data-width="fit">
+                            <option value="#kvnull"></option>
+                            <option value="test1">Test 1</option>
+                            <option value="test2">Test 2</option>
+                        </select>
+                    </div>
+                </div>""".replace("\n\\s*".toRegex(), ""),
+                document.getElementById("test")?.innerHTML,
                 "Should render correct select form control"
             )
         }
     }
-
 }

--- a/kvision-modules/kvision-bootstrap-spinner/src/main/kotlin/pl/treksoft/kvision/form/spinner/SpinnerInput.kt
+++ b/kvision-modules/kvision-bootstrap-spinner/src/main/kotlin/pl/treksoft/kvision/form/spinner/SpinnerInput.kt
@@ -23,9 +23,9 @@ package pl.treksoft.kvision.form.spinner
 
 import com.github.snabbdom.VNode
 import pl.treksoft.jquery.JQuery
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.form.FormInput
 import pl.treksoft.kvision.form.InputSize
@@ -188,35 +188,34 @@ open class SpinnerInput(
     }
 
     @Suppress("ComplexMethod")
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
-        sn.add("type" to "text")
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
+        attributeSetBuilder.add("type", "text")
         startValue?.let {
-            sn.add("value" to "$it")
+            attributeSetBuilder.add("value", "$it")
         }
         placeholder?.let {
-            sn.add("placeholder" to translate(it))
+            attributeSetBuilder.add("placeholder", translate(it))
         }
         name?.let {
-            sn.add("name" to it)
+            attributeSetBuilder.add("name", it)
         }
         autofocus?.let {
             if (it) {
-                sn.add("autofocus" to "autofocus")
+                attributeSetBuilder.add("autofocus")
             }
         }
         readonly?.let {
             if (it) {
-                sn.add("readonly" to "readonly")
+                attributeSetBuilder.add("readonly")
             }
         }
         if (disabled) {
-            sn.add("disabled" to "disabled")
+            attributeSetBuilder.add("disabled")
             value?.let {
-                sn.add("value" to "$it")
+                attributeSetBuilder.add("value", "$it")
             }
         }
-        return sn
     }
 
     protected open fun changeValue() {

--- a/kvision-modules/kvision-bootstrap-upload/src/main/kotlin/pl/treksoft/kvision/form/upload/UploadInput.kt
+++ b/kvision-modules/kvision-bootstrap-upload/src/main/kotlin/pl/treksoft/kvision/form/upload/UploadInput.kt
@@ -23,9 +23,9 @@ package pl.treksoft.kvision.form.upload
 
 import com.github.snabbdom.VNode
 import org.w3c.files.File
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.form.Form
 import pl.treksoft.kvision.form.FormInput
@@ -180,19 +180,18 @@ open class UploadInput(uploadUrl: String? = null, multiple: Boolean = false, cla
         classSetBuilder.add(size)
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
-        sn.add("type" to "file")
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
+        attributeSetBuilder.add("type", "file")
         name?.let {
-            sn.add("name" to it)
+            attributeSetBuilder.add("name", it)
         }
         if (multiple) {
-            sn.add("multiple" to "true")
+            attributeSetBuilder.add("multiple", "true")
         }
         if (disabled) {
-            sn.add("disabled" to "disabled")
+            attributeSetBuilder.add("disabled")
         }
-        return sn
     }
 
     private fun getValue(): List<KFile>? {

--- a/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/dropdown/DropDown.kt
+++ b/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/dropdown/DropDown.kt
@@ -22,6 +22,7 @@
 package pl.treksoft.kvision.dropdown
 
 import com.github.snabbdom.VNode
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Component
 import pl.treksoft.kvision.core.Container
@@ -460,23 +461,31 @@ class DropDownButton(
         }
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val inherited = super.getSnAttrs()
-        return if (forDropDown || forNavbar) {
-            inherited.filter { it.first != "type" }
-        } else {
-            inherited
-        } + listOf(
-            "data-toggle" to "dropdown", "aria-haspopup" to "true",
-            "aria-expanded" to "false", "href" to "javascript:void(0)"
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(
+            if (forDropDown || forNavbar) {
+                object : AttributeSetBuilder {
+                    override fun add(name: String, value: String) {
+                        if (name != "type") attributeSetBuilder.add(name, value)
+                    }
+                }
+            } else {
+                attributeSetBuilder
+            }
         )
+        attributeSetBuilder.add("data-toggle", "dropdown")
+        attributeSetBuilder.add("aria-haspopup", "true")
+        attributeSetBuilder.add("aria-expanded", "false")
+        attributeSetBuilder.add("href", "javascript:void(0)")
     }
 }
 
 internal class DropDownDiv(private val ariaId: String) : Div(
     null, false, null, setOf("dropdown-menu")
 ) {
-    override fun getSnAttrs(): List<StringPair> {
-        return super.getSnAttrs() + listOf("aria-labelledby" to ariaId)
+
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
+        attributeSetBuilder.add("aria-labelledby", ariaId)
     }
 }

--- a/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/modal/CloseIcon.kt
+++ b/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/modal/CloseIcon.kt
@@ -23,8 +23,8 @@ package pl.treksoft.kvision.modal
 
 import com.github.snabbdom.VNode
 import pl.treksoft.kvision.KVManager
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.ClassSetBuilder
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.core.Widget
 
 /**
@@ -41,7 +41,9 @@ open class CloseIcon : Widget(setOf()) {
         classSetBuilder.add("close")
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        return super.getSnAttrs() + listOf("type" to "button", "aria-label" to "Close")
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
+        attributeSetBuilder.add("type", "button")
+        attributeSetBuilder.add("aria-label", "Close")
     }
 }

--- a/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/navbar/Navbar.kt
+++ b/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/navbar/Navbar.kt
@@ -24,12 +24,12 @@ package pl.treksoft.kvision.navbar
 import com.github.snabbdom.VNode
 import pl.treksoft.jquery.invoke
 import pl.treksoft.jquery.jQuery
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.BsBgColor
 import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Component
 import pl.treksoft.kvision.core.Container
 import pl.treksoft.kvision.core.CssClass
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.html.Link
 import pl.treksoft.kvision.html.Span
 import pl.treksoft.kvision.html.span
@@ -273,14 +273,13 @@ internal class NavbarButton(private val idc: String, private val toggle: String 
         return render("button", childrenVNodes())
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        return super.getSnAttrs() + listOf(
-            "type" to "button",
-            "data-toggle" to "collapse",
-            "data-target" to "#$idc",
-            "aria-controls" to idc,
-            "aria-expanded" to "false",
-            "aria-label" to toggle
-        )
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
+        attributeSetBuilder.add("type", "button")
+        attributeSetBuilder.add("data-toggle", "collapse")
+        attributeSetBuilder.add("data-target", "#$idc")
+        attributeSetBuilder.add("aria-controls", idc)
+        attributeSetBuilder.add("aria-expanded", "false")
+        attributeSetBuilder.add("aria-label", toggle)
     }
 }

--- a/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/progress/NumberProgressBarTag.kt
+++ b/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/progress/NumberProgressBarTag.kt
@@ -47,10 +47,8 @@ class NumberProgressBarTag(
             update()
         }
 
-    private val unsubscribe: () -> Unit
-
     init {
-        unsubscribe = progress.bounds.subscribe { update() }
+        addAfterDisposeHook(progress.bounds.subscribe { update() })
         update()
     }
 
@@ -62,11 +60,6 @@ class NumberProgressBarTag(
         ariaMin = bounds.min.toString()
         ariaValue = value.toString()
         contentGenerator.generateContent(this, value, bounds)
-    }
-
-    override fun dispose() {
-        super.dispose()
-        unsubscribe()
     }
 }
 

--- a/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/progress/ProgressBar.kt
+++ b/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/progress/ProgressBar.kt
@@ -21,10 +21,10 @@
  */
 package pl.treksoft.kvision.progress
 
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Container
 import pl.treksoft.kvision.core.CssClass
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.html.Align
 import pl.treksoft.kvision.html.Div
 import pl.treksoft.kvision.panel.SimplePanel
@@ -247,12 +247,11 @@ internal class ProgressIndicator(
         }
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
-        sn.add("aria-valuenow" to "$progress")
-        sn.add("aria-valuemin" to "$min")
-        sn.add("aria-valuemax" to "$max")
-        return sn
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
+        attributeSetBuilder.add("aria-valuenow", "$progress")
+        attributeSetBuilder.add("aria-valuemin", "$min")
+        attributeSetBuilder.add("aria-valuemax", "$max")
     }
 }
 

--- a/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/window/MaximizeIcon.kt
+++ b/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/window/MaximizeIcon.kt
@@ -23,8 +23,8 @@ package pl.treksoft.kvision.window
 
 import com.github.snabbdom.VNode
 import pl.treksoft.kvision.KVManager
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.ClassSetBuilder
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.core.Widget
 
 /**
@@ -41,7 +41,9 @@ open class MaximizeIcon : Widget(setOf()) {
         classSetBuilder.add("close")
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        return super.getSnAttrs() + listOf("type" to "button", "aria-label" to "Maximize")
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
+        attributeSetBuilder.add("type", "button")
+        attributeSetBuilder.add("aria-label", "Maximize")
     }
 }

--- a/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/window/MinimizeIcon.kt
+++ b/kvision-modules/kvision-bootstrap/src/main/kotlin/pl/treksoft/kvision/window/MinimizeIcon.kt
@@ -23,8 +23,8 @@ package pl.treksoft.kvision.window
 
 import com.github.snabbdom.VNode
 import pl.treksoft.kvision.KVManager
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.ClassSetBuilder
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.core.Widget
 
 /**
@@ -41,7 +41,9 @@ open class MinimizeIcon : Widget(setOf()) {
         classSetBuilder.add("close")
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        return super.getSnAttrs() + listOf("type" to "button", "aria-label" to "Minimize")
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
+        attributeSetBuilder.add("type", "button")
+        attributeSetBuilder.add("aria-label", "Minimize")
     }
 }

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/OnsenUi.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/OnsenUi.kt
@@ -24,35 +24,48 @@ package pl.treksoft.kvision.onsenui
 
 import org.w3c.dom.HTMLElement
 import pl.treksoft.kvision.KVManagerOnsenui.ons
+import pl.treksoft.kvision.core.DomAttribute
 import pl.treksoft.kvision.core.Widget
 
 /**
  * Floating directions.
  */
-enum class FloatDirection(internal val type: String) {
+enum class FloatDirection(override val attributeValue: String) : DomAttribute {
     UP("up"),
     DOWN("down"),
     LEFT("left"),
-    RIGHT("right")
+    RIGHT("right"),
+    ;
+
+    override val attributeName: String
+        get() = "direction"
 }
 
 /**
  * Floating positions.
  */
-enum class FloatPosition(internal val type: String) {
+enum class FloatPosition(override val attributeValue: String) : DomAttribute {
     TOP_LEFT("top left"),
     TOP_RIGHT("top right"),
     BOTTOM_LEFT("bottom left"),
-    BOTTOM_RIGHT("bottom right")
+    BOTTOM_RIGHT("bottom right"),
+    ;
+
+    override val attributeName: String
+        get() = "position"
 }
 
 /**
  * Grid row and column vertical align.
  */
-enum class GridVerticalAlign(internal val type: String) {
+enum class GridVerticalAlign(override val attributeValue: String) : DomAttribute {
     TOP("top"),
     BOTTOM("bottom"),
-    CENTER("center")
+    CENTER("center"),
+    ;
+
+    override val attributeName: String
+        get() = "vertical-align"
 }
 
 /**

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/carousel/Carousel.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/carousel/Carousel.kt
@@ -23,10 +23,10 @@
 package pl.treksoft.kvision.onsenui.carousel
 
 import com.github.snabbdom.VNode
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.Component
 import pl.treksoft.kvision.core.Container
 import pl.treksoft.kvision.core.CssSize
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.panel.SimplePanel
 import pl.treksoft.kvision.state.ObservableState
 import pl.treksoft.kvision.state.bind
@@ -180,48 +180,47 @@ open class Carousel(
         }
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         direction?.let {
-            sn.add("direction" to it.type)
+            attributeSetBuilder.add("direction", it.type)
         }
         if (fullscreen == true) {
-            sn.add("fullscreen" to "fullscreen")
+            attributeSetBuilder.add("fullscreen")
         }
         if (overscrollable == true) {
-            sn.add("overscrollable" to "overscrollable")
+            attributeSetBuilder.add("overscrollable")
         }
         if (animation == false) {
-            sn.add("animation" to "none")
+            attributeSetBuilder.add("animation", "none")
         }
         if (swipeable == true) {
-            sn.add("swipeable" to "swipeable")
+            attributeSetBuilder.add("swipeable")
         }
         initialIndex?.let {
-            sn.add("initial-index" to "$it")
+            attributeSetBuilder.add("initial-index", "$it")
         }
         if (centered == true) {
-            sn.add("centered" to "centered")
+            attributeSetBuilder.add("centered")
         }
         itemWidth?.let {
-            sn.add("item-width" to it.asString())
+            attributeSetBuilder.add("item-width", it.asString())
         }
         itemHeight?.let {
-            sn.add("item-height" to it.asString())
+            attributeSetBuilder.add("item-height", it.asString())
         }
         if (autoScroll == true) {
-            sn.add("auto-scroll" to "auto-scroll")
+            attributeSetBuilder.add("auto-scroll")
         }
         autoScrollRatio?.let {
-            sn.add("auto-scroll-ratio" to "$it")
+            attributeSetBuilder.add("auto-scroll-ratio", "$it")
         }
         if (disabled == true) {
-            sn.add("disabled" to "disabled")
+            attributeSetBuilder.add("disabled")
         }
         if (autoRefresh == true) {
-            sn.add("auto-refresh" to "auto-refresh")
+            attributeSetBuilder.add("auto-refresh")
         }
-        return sn
     }
 
     override fun add(child: Component): SimplePanel {

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/control/Fab.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/control/Fab.kt
@@ -24,8 +24,8 @@ package pl.treksoft.kvision.onsenui.control
 
 import com.github.snabbdom.VNode
 import org.w3c.dom.events.MouseEvent
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.html.CustomTag
 import pl.treksoft.kvision.onsenui.FloatPosition
 import pl.treksoft.kvision.onsenui.visual.Icon
@@ -111,21 +111,18 @@ open class Fab(
         return iconArr + super.childrenVNodes()
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
-        floatPosition?.let {
-            sn.add("position" to it.type)
-        }
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
+        attributeSetBuilder.add(floatPosition)
         if (ripple == true) {
-            sn.add("ripple" to "ripple")
+            attributeSetBuilder.add("ripple")
         }
         modifier?.let {
-            sn.add("modifier" to it)
+            attributeSetBuilder.add("modifier", it)
         }
         if (disabled == true) {
-            sn.add("disabled" to "disabled")
+            attributeSetBuilder.add("disabled")
         }
-        return sn
     }
 
     /**

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/control/Segment.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/control/Segment.kt
@@ -23,8 +23,8 @@
 package pl.treksoft.kvision.onsenui.control
 
 import com.github.snabbdom.VNode
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.onsenui.tabbar.Tabbar
 import pl.treksoft.kvision.panel.SimplePanel
 import pl.treksoft.kvision.utils.obj
@@ -72,21 +72,20 @@ open class Segment(
         return render("ons-segment", childrenVNodes())
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         tabbar?.id?.let {
-            sn.add("tabbar-id" to it)
+            attributeSetBuilder.add("tabbar-id", it)
         }
         activeIndex?.let {
-            sn.add("active-index" to "$it")
+            attributeSetBuilder.add("active-index", "$it")
         }
         if (disabled == true) {
-            sn.add("disabled" to "disabled")
+            attributeSetBuilder.add("disabled")
         }
         modifier?.let {
-            sn.add("modifier" to it)
+            attributeSetBuilder.add("modifier", it)
         }
-        return sn
     }
 
     @Suppress("UnsafeCastFromDynamic")

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/control/SpeedDial.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/control/SpeedDial.kt
@@ -24,8 +24,8 @@ package pl.treksoft.kvision.onsenui.control
 
 import com.github.snabbdom.VNode
 import org.w3c.dom.events.MouseEvent
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.html.CustomTag
 import pl.treksoft.kvision.onsenui.FloatDirection
 import pl.treksoft.kvision.onsenui.FloatPosition
@@ -128,24 +128,19 @@ open class SpeedDial(
         return iconArr + super.childrenVNodes()
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
-        floatPosition?.let {
-            sn.add("position" to it.type)
-        }
-        floatDirection?.let {
-            sn.add("direction" to it.type)
-        }
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
+        attributeSetBuilder.add(floatPosition)
+        attributeSetBuilder.add(floatDirection)
         if (ripple == true) {
-            sn.add("ripple" to "ripple")
+            attributeSetBuilder.add("ripple")
         }
         modifier?.let {
-            sn.add("modifier" to it)
+            attributeSetBuilder.add("modifier", it)
         }
         if (disabled == true) {
-            sn.add("disabled" to "disabled")
+            attributeSetBuilder.add("disabled")
         }
-        return sn
     }
 
     @Suppress("UnsafeCastFromDynamic")

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/control/SpeedDialItem.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/control/SpeedDialItem.kt
@@ -24,7 +24,7 @@ package pl.treksoft.kvision.onsenui.control
 
 import com.github.snabbdom.VNode
 import org.w3c.dom.events.MouseEvent
-import pl.treksoft.kvision.core.StringPair
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.html.CustomTag
 import pl.treksoft.kvision.onsenui.visual.Icon
 import pl.treksoft.kvision.utils.set
@@ -87,15 +87,14 @@ open class SpeedDialItem(
         return iconArr + super.childrenVNodes()
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         if (ripple == true) {
-            sn.add("ripple" to "ripple")
+            attributeSetBuilder.add("ripple")
         }
         modifier?.let {
-            sn.add("modifier" to it)
+            attributeSetBuilder.add("modifier", it)
         }
-        return sn
     }
 
     /**

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/core/BackButton.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/core/BackButton.kt
@@ -24,8 +24,8 @@ package pl.treksoft.kvision.onsenui.core
 
 import com.github.snabbdom.VNode
 import org.w3c.dom.events.MouseEvent
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.Component
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.html.Align
 import pl.treksoft.kvision.html.CustomTag
 import pl.treksoft.kvision.html.Div
@@ -59,12 +59,11 @@ open class BackButton(
         init?.invoke(this)
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         modifier?.let {
-            sn.add("modifier" to it)
+            attributeSetBuilder.add("modifier", it)
         }
-        return sn
     }
 
     override fun afterInsert(node: VNode) {

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/core/Navigator.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/core/Navigator.kt
@@ -24,8 +24,9 @@ package pl.treksoft.kvision.onsenui.core
 
 import com.github.snabbdom.VNode
 import pl.treksoft.kvision.KVManagerOnsenui.ons
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.Display
-import pl.treksoft.kvision.core.StringPair
+import pl.treksoft.kvision.core.DomAttribute
 import pl.treksoft.kvision.onsenui.BackButtonEvent
 import pl.treksoft.kvision.onsenui.splitter.SplitterContent
 import pl.treksoft.kvision.onsenui.tabbar.Tab
@@ -39,7 +40,7 @@ import kotlin.js.Promise
 /**
  * Navigator animation types.
  */
-enum class NavAnimation(internal val type: String) {
+enum class NavAnimation(override val attributeValue: String) : DomAttribute {
     NONE("none"),
     FADE("fade"),
     LIFT("lift"),
@@ -49,7 +50,11 @@ enum class NavAnimation(internal val type: String) {
     SLIDEMD("slide-md"),
     FADEIOS("fade-ios"),
     LIFTIOS("lift-ios"),
-    SLIDEIOS("slide-ios")
+    SLIDEIOS("slide-ios"),
+    ;
+
+    override val attributeName: String
+        get() = "animation"
 }
 
 /**
@@ -128,23 +133,20 @@ open class Navigator(
         return render("ons-navigator", childrenVNodes())
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
-        animation?.let {
-            sn.add("animation" to it.type)
-        }
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
+        attributeSetBuilder.add(animation)
         if (forceSwipeable == true) {
-            sn.add("swipeable" to "force")
+            attributeSetBuilder.add("swipeable", "force")
         } else if (swipeable == true) {
-            sn.add("swipeable" to "swipeable")
+            attributeSetBuilder.add("swipeable")
         }
         swipeTargetWidth?.let {
-            sn.add("swipe-target-width" to "${it}px")
+            attributeSetBuilder.add("swipe-target-width", "${it}px")
         }
         swipeThreshold?.let {
-            sn.add("swipe-threshold" to "$it")
+            attributeSetBuilder.add("swipe-threshold", "$it")
         }
-        return sn
     }
 
     @Suppress("UnsafeCastFromDynamic")

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/core/Page.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/core/Page.kt
@@ -23,9 +23,9 @@
 package pl.treksoft.kvision.onsenui.core
 
 import com.github.snabbdom.VNode
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.Component
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.html.Span
 import pl.treksoft.kvision.onsenui.BackButtonEvent
 import pl.treksoft.kvision.onsenui.dialog.Dialog
@@ -109,12 +109,11 @@ open class Page(classes: Set<String> = setOf(), init: (Page.() -> Unit)? = null)
         )
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         modifier?.let {
-            sn.add("modifier" to it)
+            attributeSetBuilder.add("modifier", it)
         }
-        return sn
     }
 
     override fun afterInsert(node: VNode) {

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/core/PullHook.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/core/PullHook.kt
@@ -23,8 +23,8 @@
 package pl.treksoft.kvision.onsenui.core
 
 import com.github.snabbdom.VNode
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.CssSize
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.html.Align
 import pl.treksoft.kvision.html.CustomTag
 import pl.treksoft.kvision.utils.asString
@@ -98,21 +98,20 @@ open class PullHook(
         init?.invoke(this)
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         pullHeight?.let {
-            sn.add("height" to it.asString())
+            attributeSetBuilder.add("height", it.asString())
         }
         thresholdHeight?.let {
-            sn.add("threshold-height" to it.asString())
+            attributeSetBuilder.add("threshold-height", it.asString())
         }
         if (fixedContent == true) {
-            sn.add("fixed-content" to "fixed-content")
+            attributeSetBuilder.add("fixed-content")
         }
         if (disabled == true) {
-            sn.add("disabled" to "disabled")
+            attributeSetBuilder.add("disabled")
         }
-        return sn
     }
 
     @Suppress("UnsafeCastFromDynamic")

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/dialog/ActionSheet.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/dialog/ActionSheet.kt
@@ -23,9 +23,9 @@
 package pl.treksoft.kvision.onsenui.dialog
 
 import com.github.snabbdom.VNode
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.Container
 import pl.treksoft.kvision.core.Display
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.onsenui.BackButtonEvent
 import pl.treksoft.kvision.panel.Root
@@ -129,27 +129,26 @@ open class ActionSheet(
         }
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         actionSheetTitle?.let {
-            sn.add("title" to it)
+            attributeSetBuilder.add("title", it)
         }
         if (cancelable == true) {
-            sn.add("cancelable" to "cancelable")
+            attributeSetBuilder.add("cancelable")
         }
         if (animation == false) {
-            sn.add("animation" to "none")
+            attributeSetBuilder.add("animation", "none")
         }
         maskColor?.let {
-            sn.add("mask-color" to it)
+            attributeSetBuilder.add("mask-color", it)
         }
         if (disabled == true) {
-            sn.add("disabled" to "disabled")
+            attributeSetBuilder.add("disabled")
         }
         modifier?.let {
-            sn.add("modifier" to it)
+            attributeSetBuilder.add("modifier", it)
         }
-        return sn
     }
 
     /**

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/dialog/ActionSheetButton.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/dialog/ActionSheetButton.kt
@@ -23,7 +23,7 @@
 package pl.treksoft.kvision.onsenui.dialog
 
 import org.w3c.dom.events.MouseEvent
-import pl.treksoft.kvision.core.StringPair
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.html.Align
 import pl.treksoft.kvision.html.CustomTag
 import pl.treksoft.kvision.utils.set
@@ -63,15 +63,14 @@ open class ActionSheetButton(
         init?.invoke(this)
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         icon?.let {
-            sn.add("icon" to it)
+            attributeSetBuilder.add("icon", it)
         }
         modifier?.let {
-            sn.add("modifier" to it)
+            attributeSetBuilder.add("modifier", it)
         }
-        return sn
     }
 
     /**

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/dialog/AlertDialog.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/dialog/AlertDialog.kt
@@ -23,9 +23,9 @@
 package pl.treksoft.kvision.onsenui.dialog
 
 import com.github.snabbdom.VNode
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.Component
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.html.Div
 import pl.treksoft.kvision.panel.SimplePanel
 import pl.treksoft.kvision.utils.set
@@ -94,14 +94,13 @@ open class AlertDialog(
         )
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         val modRowfooter = if (rowfooter == true) "rowfooter" else null
         val modList = listOfNotNull(modifier, modRowfooter)
         if (modList.isNotEmpty()) {
-            sn.add("modifier" to modList.joinToString(" "))
+            attributeSetBuilder.add("modifier", modList.joinToString(" "))
         }
-        return sn
     }
 
     override fun add(child: Component): SimplePanel {

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/dialog/AlertDialogButton.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/dialog/AlertDialogButton.kt
@@ -23,7 +23,7 @@
 package pl.treksoft.kvision.onsenui.dialog
 
 import org.w3c.dom.events.MouseEvent
-import pl.treksoft.kvision.core.StringPair
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.html.Align
 import pl.treksoft.kvision.html.CustomTag
 import pl.treksoft.kvision.utils.set
@@ -63,15 +63,14 @@ open class AlertDialogButton(
         init?.invoke(this)
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         icon?.let {
-            sn.add("icon" to it)
+            attributeSetBuilder.add("icon", it)
         }
         modifier?.let {
-            sn.add("modifier" to it)
+            attributeSetBuilder.add("modifier", it)
         }
-        return sn
     }
 
     /**

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/dialog/Dialog.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/dialog/Dialog.kt
@@ -23,9 +23,9 @@
 package pl.treksoft.kvision.onsenui.dialog
 
 import com.github.snabbdom.VNode
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.Container
 import pl.treksoft.kvision.core.Display
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.onsenui.BackButtonEvent
 import pl.treksoft.kvision.panel.Root
@@ -122,24 +122,23 @@ open class Dialog(
         }
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         if (cancelable == true) {
-            sn.add("cancelable" to "cancelable")
+            attributeSetBuilder.add("cancelable")
         }
         if (animation == false) {
-            sn.add("animation" to "none")
+            attributeSetBuilder.add("animation", "none")
         }
         maskColor?.let {
-            sn.add("mask-color" to it)
+            attributeSetBuilder.add("mask-color", it)
         }
         if (disabled == true) {
-            sn.add("disabled" to "disabled")
+            attributeSetBuilder.add("disabled")
         }
         modifier?.let {
-            sn.add("modifier" to it)
+            attributeSetBuilder.add("modifier", it)
         }
-        return sn
     }
 
     /**

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/dialog/Modal.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/dialog/Modal.kt
@@ -23,9 +23,10 @@
 package pl.treksoft.kvision.onsenui.dialog
 
 import com.github.snabbdom.VNode
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.Container
 import pl.treksoft.kvision.core.Display
-import pl.treksoft.kvision.core.StringPair
+import pl.treksoft.kvision.core.DomAttribute
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.onsenui.BackButtonEvent
 import pl.treksoft.kvision.panel.Root
@@ -35,10 +36,14 @@ import pl.treksoft.kvision.utils.obj
 import pl.treksoft.kvision.utils.set
 import kotlin.js.Promise
 
-enum class ModalAnimation(internal val type: String) {
+enum class ModalAnimation(override val attributeValue: String) : DomAttribute {
     NONE("none"),
     FADE("fade"),
-    LIFT("lift")
+    LIFT("lift"),
+    ;
+
+    override val attributeName: String
+        get() = "animation"
 }
 
 /**
@@ -106,12 +111,9 @@ open class Modal(
         }
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
-        animation?.let {
-            sn.add("animation" to it.type)
-        }
-        return sn
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
+        attributeSetBuilder.add(animation)
     }
 
     /**

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/dialog/Notification.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/dialog/Notification.kt
@@ -246,7 +246,7 @@ fun showToast(
             this.buttonLabel = it
         }
         animation?.let {
-            this.animation = it.type
+            this.animation = it.attributeValue
         }
         timeout?.let {
             this.timeout = it

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/dialog/Popover.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/dialog/Popover.kt
@@ -23,8 +23,8 @@
 package pl.treksoft.kvision.onsenui.dialog
 
 import com.github.snabbdom.VNode
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.onsenui.BackButtonEvent
 import pl.treksoft.kvision.onsenui.FloatDirection
@@ -134,30 +134,27 @@ open class Popover(
         }
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
-        direction?.let {
-            sn.add("direction" to it.type)
-        }
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
+        attributeSetBuilder.add(direction)
         if (cancelable == true) {
-            sn.add("cancelable" to "cancelable")
+            attributeSetBuilder.add("cancelable")
         }
         if (animation == false) {
-            sn.add("animation" to "none")
+            attributeSetBuilder.add("animation", "none")
         }
         maskColor?.let {
-            sn.add("mask-color" to it)
+            attributeSetBuilder.add("mask-color", it)
         }
         if (disabled == true) {
-            sn.add("disabled" to "disabled")
+            attributeSetBuilder.add("disabled")
         }
         if (coverTarget == true) {
-            sn.add("cover-target" to "cover-target")
+            attributeSetBuilder.add("cover-target")
         }
         modifier?.let {
-            sn.add("modifier" to it)
+            attributeSetBuilder.add("modifier", it)
         }
-        return sn
     }
 
     /**

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/dialog/Toast.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/dialog/Toast.kt
@@ -23,9 +23,10 @@
 package pl.treksoft.kvision.onsenui.dialog
 
 import com.github.snabbdom.VNode
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.Container
 import pl.treksoft.kvision.core.Display
-import pl.treksoft.kvision.core.StringPair
+import pl.treksoft.kvision.core.DomAttribute
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.onsenui.BackButtonEvent
 import pl.treksoft.kvision.panel.Root
@@ -35,12 +36,16 @@ import pl.treksoft.kvision.utils.obj
 import pl.treksoft.kvision.utils.set
 import kotlin.js.Promise
 
-enum class ToastAnimation(internal val type: String) {
+enum class ToastAnimation(override val attributeValue: String) : DomAttribute {
     NONE("none"),
     FADE("fade"),
     LIFT("lift"),
     ASCEND("ascend"),
-    FALL("fall")
+    FALL("fall"),
+    ;
+
+    override val attributeName: String
+        get() = "animation"
 }
 
 /**
@@ -108,12 +113,9 @@ open class Toast(
         }
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
-        animation?.let {
-            sn.add("animation" to it.type)
-        }
-        return sn
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        attributeSetBuilder.add(animation)
+        super.buildAttributesSet(attributeSetBuilder)
     }
 
     /**

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/form/OnsButton.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/form/OnsButton.kt
@@ -23,9 +23,9 @@
 package pl.treksoft.kvision.onsenui.form
 
 import org.w3c.dom.events.MouseEvent
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.html.Align
 import pl.treksoft.kvision.html.CustomTag
 import pl.treksoft.kvision.utils.set
@@ -118,16 +118,16 @@ open class OnsButton(
         }
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         icon?.let {
-            sn.add("icon" to it)
+            attributeSetBuilder.add("icon", it)
         }
         if (ripple == true) {
-            sn.add("ripple" to "ripple")
+            attributeSetBuilder.add("ripple")
         }
         if (disabled == true) {
-            sn.add("disabled" to "disabled")
+            attributeSetBuilder.add("disabled")
         }
         val modifiers = mutableListOf<String>()
         buttonType?.let {
@@ -140,9 +140,8 @@ open class OnsButton(
             modifiers.add(it)
         }
         if (modifiers.isNotEmpty()) {
-            sn.add("modifier" to modifiers.joinToString(" "))
+            attributeSetBuilder.add("modifier", modifiers.joinToString(" "))
         }
-        return sn
     }
 
     /**

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/form/OnsCheckBoxInput.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/form/OnsCheckBoxInput.kt
@@ -23,12 +23,12 @@
 package pl.treksoft.kvision.onsenui.form
 
 import com.github.snabbdom.VNode
+import kotlinx.browser.window
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.form.check.CheckInput
 import pl.treksoft.kvision.form.check.CheckInputType
 import pl.treksoft.kvision.utils.set
-import kotlinx.browser.window
 
 /**
  * OnsenUI checkbox input component.
@@ -65,15 +65,14 @@ open class OnsCheckBoxInput(
         return render("ons-checkbox")
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         inputId?.let {
-            sn.add("input-id" to it)
+            attributeSetBuilder.add("input-id", it)
         }
         modifier?.let {
-            sn.add("modifier" to it)
+            attributeSetBuilder.add("modifier", it)
         }
-        return sn
     }
 
     override fun afterInsert(node: VNode) {

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/form/OnsDateTimeInput.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/form/OnsDateTimeInput.kt
@@ -23,9 +23,9 @@
 package pl.treksoft.kvision.onsenui.form
 
 import com.github.snabbdom.VNode
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.form.FormInput
 import pl.treksoft.kvision.form.InputSize
@@ -169,55 +169,53 @@ open class OnsDateTimeInput(
         classSetBuilder.add(size)
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
-        when (mode) {
-            DateTimeMode.DATE -> sn.add("type" to "date")
-            DateTimeMode.TIME -> sn.add("type" to "time")
-            DateTimeMode.DATETIME -> sn.add("type" to "datetime-local")
-        }
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
+        attributeSetBuilder.add(
+            "type",
+            when (mode) {
+                DateTimeMode.DATE -> "date"
+                DateTimeMode.TIME -> "time"
+                DateTimeMode.DATETIME -> "datetime-local"
+            }
+        )
         startValue?.let {
-            sn.add("value" to it.toStringF(mode.format))
+            attributeSetBuilder.add("value", it.toStringF(mode.format))
         }
         min?.let {
-            sn.add("min" to it.toStringF(mode.format))
+            attributeSetBuilder.add("min", it.toStringF(mode.format))
         }
         max?.let {
-            sn.add("max" to it.toStringF(mode.format))
+            attributeSetBuilder.add("max", it.toStringF(mode.format))
         }
         step?.let {
-            sn.add("step" to "$it")
+            attributeSetBuilder.add("step", "$it")
         }
         inputId?.let {
-            sn.add("input-id" to it)
+            attributeSetBuilder.add("input-id", it)
         }
         modifier?.let {
-            sn.add("modifier" to it)
+            attributeSetBuilder.add("modifier", it)
         }
         name?.let {
-            sn.add("name" to it)
+            attributeSetBuilder.add("name", it)
         }
         autofocus?.let {
             if (it) {
-                sn.add("autofocus" to "autofocus")
+                attributeSetBuilder.add("autofocus")
             }
         }
         readonly?.let {
             if (it) {
-                sn.add("readonly" to "readonly")
+                attributeSetBuilder.add("readonly")
             }
         }
         if (disabled) {
-            sn.add("disabled" to "disabled")
+            attributeSetBuilder.add("disabled")
         }
         autocomplete?.let {
-            if (it) {
-                sn.add("autocomplete" to "on")
-            } else {
-                sn.add("autocomplete" to "off")
-            }
+            attributeSetBuilder.add("autocomplete", if (it) "on" else "off")
         }
-        return sn
     }
 
     override fun afterInsert(node: VNode) {

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/form/OnsNumberInput.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/form/OnsNumberInput.kt
@@ -23,9 +23,9 @@
 package pl.treksoft.kvision.onsenui.form
 
 import com.github.snabbdom.VNode
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.form.FormInput
 import pl.treksoft.kvision.form.InputSize
@@ -166,55 +166,50 @@ open class OnsNumberInput(
         classSetBuilder.add(size)
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
-        sn.add("type" to "number")
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
+        attributeSetBuilder.add("type", "number")
         startValue?.let {
-            sn.add("value" to "$it")
+            attributeSetBuilder.add("value", "$it")
         }
         min?.let {
-            sn.add("min" to "$it")
+            attributeSetBuilder.add("min", "$it")
         }
         max?.let {
-            sn.add("max" to "$it")
+            attributeSetBuilder.add("max", "$it")
         }
-        sn.add("step" to step.toString())
+        attributeSetBuilder.add("step", step.toString())
         placeholder?.let {
-            sn.add("placeholder" to translate(it))
+            attributeSetBuilder.add("placeholder", translate(it))
         }
         if (floatLabel == true) {
-            sn.add("float" to "float")
+            attributeSetBuilder.add("float")
         }
         inputId?.let {
-            sn.add("input-id" to it)
+            attributeSetBuilder.add("input-id", it)
         }
         modifier?.let {
-            sn.add("modifier" to it)
+            attributeSetBuilder.add("modifier", it)
         }
         name?.let {
-            sn.add("name" to it)
+            attributeSetBuilder.add("name", it)
         }
         autofocus?.let {
             if (it) {
-                sn.add("autofocus" to "autofocus")
+                attributeSetBuilder.add("autofocus")
             }
         }
         readonly?.let {
             if (it) {
-                sn.add("readonly" to "readonly")
+                attributeSetBuilder.add("readonly")
             }
         }
         if (disabled) {
-            sn.add("disabled" to "disabled")
+            attributeSetBuilder.add("disabled")
         }
         autocomplete?.let {
-            if (it) {
-                sn.add("autocomplete" to "on")
-            } else {
-                sn.add("autocomplete" to "off")
-            }
+            attributeSetBuilder.add("autocomplete", if (it) "on" else "off")
         }
-        return sn
     }
 
     override fun afterInsert(node: VNode) {

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/form/OnsRadioInput.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/form/OnsRadioInput.kt
@@ -23,12 +23,12 @@
 package pl.treksoft.kvision.onsenui.form
 
 import com.github.snabbdom.VNode
+import kotlinx.browser.window
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.form.check.CheckInput
 import pl.treksoft.kvision.form.check.CheckInputType
 import pl.treksoft.kvision.utils.set
-import kotlinx.browser.window
 
 /**
  * OnsenUI radio button input component.
@@ -65,15 +65,14 @@ open class OnsRadioInput(
         return render("ons-radio")
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         inputId?.let {
-            sn.add("input-id" to it)
+            attributeSetBuilder.add("input-id", it)
         }
         modifier?.let {
-            sn.add("modifier" to it)
+            attributeSetBuilder.add("modifier", it)
         }
-        return sn
     }
 
     override fun afterInsert(node: VNode) {

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/form/OnsRangeInput.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/form/OnsRangeInput.kt
@@ -23,8 +23,8 @@
 package pl.treksoft.kvision.onsenui.form
 
 import com.github.snabbdom.VNode
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.form.range.RangeInput
 import pl.treksoft.kvision.utils.set
 
@@ -69,15 +69,14 @@ open class OnsRangeInput(
         return render("ons-range")
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         inputId?.let {
-            sn.add("input-id" to it)
+            attributeSetBuilder.add("input-id", it)
         }
         modifier?.let {
-            sn.add("modifier" to it)
+            attributeSetBuilder.add("modifier", it)
         }
-        return sn
     }
 }
 

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/form/OnsSelectInput.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/form/OnsSelectInput.kt
@@ -23,11 +23,12 @@
 package pl.treksoft.kvision.onsenui.form
 
 import com.github.snabbdom.VNode
+import kotlinx.browser.window
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.Container
 import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.form.select.SimpleSelectInput
 import pl.treksoft.kvision.utils.set
-import kotlinx.browser.window
 
 /**
  * OnsenUI select input component.
@@ -77,15 +78,14 @@ open class OnsSelectInput(
         return render("ons-select", childrenVNodes())
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         selectId?.let {
-            sn.add("select-id" to it)
+            attributeSetBuilder.add("select-id", it)
         }
         modifier?.let {
-            sn.add("modifier" to it)
+            attributeSetBuilder.add("modifier", it)
         }
-        return sn
     }
 
     override fun afterInsert(node: VNode) {

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/form/OnsTextInput.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/form/OnsTextInput.kt
@@ -23,8 +23,8 @@
 package pl.treksoft.kvision.onsenui.form
 
 import com.github.snabbdom.VNode
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.form.text.TextInput
 import pl.treksoft.kvision.form.text.TextInputType
 import pl.treksoft.kvision.utils.set
@@ -80,18 +80,17 @@ open class OnsTextInput(
         }
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         if (floatLabel == true) {
-            sn.add("float" to "float")
+            attributeSetBuilder.add("float")
         }
         inputId?.let {
-            sn.add("input-id" to it)
+            attributeSetBuilder.add("input-id", it)
         }
         modifier?.let {
-            sn.add("modifier" to it)
+            attributeSetBuilder.add("modifier", it)
         }
-        return sn
     }
 }
 

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/grid/Col.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/grid/Col.kt
@@ -22,8 +22,8 @@
 
 package pl.treksoft.kvision.onsenui.grid
 
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.CssSize
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.html.Align
 import pl.treksoft.kvision.html.CustomTag
 import pl.treksoft.kvision.onsenui.GridVerticalAlign
@@ -67,15 +67,14 @@ open class Col(
         init?.invoke(this)
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         colWidth?.let {
-            sn.add("width" to it.asString())
+            attributeSetBuilder.add("width", it.asString())
         }
         colVerticalAlign?.let {
-            sn.add("vertical-align" to it.type)
+            attributeSetBuilder.add("vertical-align", it.attributeValue)
         }
-        return sn
     }
 }
 

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/grid/Row.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/grid/Row.kt
@@ -23,8 +23,8 @@
 package pl.treksoft.kvision.onsenui.grid
 
 import com.github.snabbdom.VNode
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.onsenui.GridVerticalAlign
 import pl.treksoft.kvision.panel.SimplePanel
 import pl.treksoft.kvision.utils.set
@@ -57,12 +57,9 @@ open class Row(
         return render("ons-row", childrenVNodes())
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
-        rowVerticalAlign?.let {
-            sn.add("vertical-align" to it.type)
-        }
-        return sn
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
+        attributeSetBuilder.add(rowVerticalAlign)
     }
 }
 

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/list/OnsList.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/list/OnsList.kt
@@ -23,8 +23,8 @@
 package pl.treksoft.kvision.onsenui.list
 
 import com.github.snabbdom.VNode
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.panel.SimplePanel
 import pl.treksoft.kvision.state.ObservableState
 import pl.treksoft.kvision.state.bind
@@ -70,8 +70,8 @@ open class OnsList(
         return render("ons-list", childrenVNodes())
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         val modifiers = mutableListOf<String>()
         if (inset == true) {
             modifiers.add("inset")
@@ -83,9 +83,8 @@ open class OnsList(
             modifiers.add(it)
         }
         if (modifiers.isNotEmpty()) {
-            sn.add("modifier" to modifiers.joinToString(" "))
+            attributeSetBuilder.add("modifier", modifiers.joinToString(" "))
         }
-        return sn
     }
 }
 

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/list/OnsListHeader.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/list/OnsListHeader.kt
@@ -22,7 +22,7 @@
 
 package pl.treksoft.kvision.onsenui.list
 
-import pl.treksoft.kvision.core.StringPair
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.html.Align
 import pl.treksoft.kvision.html.CustomTag
 import pl.treksoft.kvision.utils.set
@@ -55,12 +55,11 @@ open class OnsListHeader(
         init?.invoke(this)
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         modifier?.let {
-            sn.add("modifier" to it)
+            attributeSetBuilder.add("modifier", it)
         }
-        return sn
     }
 }
 

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/list/OnsListItem.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/list/OnsListItem.kt
@@ -23,9 +23,9 @@
 package pl.treksoft.kvision.onsenui.list
 
 import com.github.snabbdom.VNode
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.Color
 import pl.treksoft.kvision.core.Component
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.html.Div
 import pl.treksoft.kvision.panel.SimplePanel
 import pl.treksoft.kvision.utils.set
@@ -154,22 +154,22 @@ open class OnsListItem(
         )
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         if (lockOnDrag == true) {
-            sn.add("lock-on-drag" to "lock-on-drag")
+            attributeSetBuilder.add("lock-on-drag")
         }
         if (tappable == true) {
-            sn.add("tappable" to "tappable")
+            attributeSetBuilder.add("tappable")
         }
         tapBackgroundColor?.let {
-            sn.add("tap-background-color" to it.asString())
+            attributeSetBuilder.add("tap-background-color", it.asString())
         }
         if (expandablePanel.content != null || expandablePanel.getChildren().isNotEmpty()) {
-            sn.add("expandable" to "expandable")
+            attributeSetBuilder.add("expandable")
         }
         if (animation == false) {
-            sn.add("animation" to "none")
+            attributeSetBuilder.add("animation", "none")
         }
         val modifiers = mutableListOf<String>()
         divider?.let {
@@ -179,9 +179,8 @@ open class OnsListItem(
             modifiers.add(it)
         }
         if (modifiers.isNotEmpty()) {
-            sn.add("modifier" to modifiers.joinToString(" "))
+            attributeSetBuilder.add("modifier", modifiers.joinToString(" "))
         }
-        return sn
     }
 
     override fun add(child: Component): SimplePanel {

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/list/OnsListTitle.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/list/OnsListTitle.kt
@@ -22,8 +22,8 @@
 
 package pl.treksoft.kvision.onsenui.list
 
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.html.Align
 import pl.treksoft.kvision.html.CustomTag
 import pl.treksoft.kvision.utils.set
@@ -56,12 +56,11 @@ open class OnsListTitle(
         init?.invoke(this)
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         modifier?.let {
-            sn.add("modifier" to it)
+            attributeSetBuilder.add("modifier", it)
         }
-        return sn
     }
 }
 

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/splitter/SplitterSide.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/splitter/SplitterSide.kt
@@ -25,8 +25,9 @@ package pl.treksoft.kvision.onsenui.splitter
 import com.github.snabbdom.VNode
 import org.w3c.dom.HTMLElement
 import pl.treksoft.kvision.KVManagerOnsenui.ons
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.CssSize
-import pl.treksoft.kvision.core.StringPair
+import pl.treksoft.kvision.core.DomAttribute
 import pl.treksoft.kvision.onsenui.core.Page
 import pl.treksoft.kvision.panel.SimplePanel
 import pl.treksoft.kvision.utils.asString
@@ -38,27 +39,39 @@ import kotlin.js.Promise
 /**
  * Splitter side animation types.
  */
-enum class SideAnimation(internal val type: String) {
+enum class SideAnimation(override val attributeValue: String) : DomAttribute {
     OVERLAY("overlay"),
     PUSH("push"),
-    REVEAL("reveal")
+    REVEAL("reveal"),
+    ;
+
+    override val attributeName: String
+        get() = "animation"
 }
 
 /**
  * Splitter side collapse types.
  */
-enum class Collapse(internal val type: String) {
+enum class Collapse(override val attributeValue: String) : DomAttribute {
     COLLAPSE("collapse"),
     PORTRAIT("portrait"),
-    LANDSCAPE("landscape")
+    LANDSCAPE("landscape"),
+    ;
+
+    override val attributeName: String
+        get() = "collapse"
 }
 
 /**
  * Splitter side positions.
  */
-enum class Side(internal val type: String) {
+enum class Side(override val attributeValue: String) : DomAttribute {
     LEFT("left"),
-    RIGHT("right")
+    RIGHT("right"),
+    ;
+
+    override val attributeName: String
+        get() = "side"
 }
 
 /**
@@ -153,30 +166,23 @@ open class SplitterSide(
         return render("ons-splitter-side", childrenVNodes())
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
-        animation?.let {
-            sn.add("animation" to it.type)
-        }
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
+        attributeSetBuilder.add(animation)
         if (swipeable == true) {
-            sn.add("swipeable" to "swipeable")
+            attributeSetBuilder.add("swipeable")
         }
-        collapse?.let {
-            sn.add("collapse" to it.type)
-        }
-        side?.let {
-            sn.add("side" to it.type)
-        }
+        attributeSetBuilder.add(collapse)
+        attributeSetBuilder.add(side)
         openThreshold?.let {
-            sn.add("open-threshold" to "$it")
+            attributeSetBuilder.add("open-threshold", "$it")
         }
         swipeTargetWidth?.let {
-            sn.add("swipe-target-width" to "${it}px")
+            attributeSetBuilder.add("swipe-target-width", "${it}px")
         }
         sideWidth?.let {
-            sn.add("width" to it.asString())
+            attributeSetBuilder.add("width", it.asString())
         }
-        return sn
     }
 
     @Suppress("UnsafeCastFromDynamic")

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/tabbar/Tab.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/tabbar/Tab.kt
@@ -24,8 +24,8 @@ package pl.treksoft.kvision.onsenui.tabbar
 
 import com.github.snabbdom.VNode
 import pl.treksoft.kvision.KVManagerOnsenui.ons
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.Component
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.onsenui.core.Navigator
 import pl.treksoft.kvision.onsenui.core.Page
@@ -94,25 +94,24 @@ open class Tab(
         return render("ons-tab", childrenVNodes())
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
-        sn.add("page" to idc)
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
+        attributeSetBuilder.add("page", idc)
         label?.let {
-            sn.add("label" to it)
+            attributeSetBuilder.add("label", it)
         }
         icon?.let {
-            sn.add("icon" to it)
+            attributeSetBuilder.add("icon", it)
         }
         activeIcon?.let {
-            sn.add("active-icon" to it)
+            attributeSetBuilder.add("active-icon", it)
         }
         badge?.let {
-            sn.add("badge" to it)
+            attributeSetBuilder.add("badge", it)
         }
         if (active == true) {
-            sn.add("active" to "active")
+            attributeSetBuilder.add("active")
         }
-        return sn
     }
 
     override fun afterInsert(node: VNode) {

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/tabbar/Tabbar.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/tabbar/Tabbar.kt
@@ -23,7 +23,8 @@
 package pl.treksoft.kvision.onsenui.tabbar
 
 import com.github.snabbdom.VNode
-import pl.treksoft.kvision.core.StringPair
+import pl.treksoft.kvision.core.AttributeSetBuilder
+import pl.treksoft.kvision.core.DomAttribute
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.onsenui.core.Page
 import pl.treksoft.kvision.panel.SimplePanel
@@ -34,10 +35,14 @@ import kotlin.js.Promise
 /**
  * Tab bar position.
  */
-enum class TabsPosition(internal val type: String) {
+enum class TabsPosition(override val attributeValue: String) : DomAttribute {
     AUTO("auto"),
     TOP("top"),
-    BOTTOM("bottom")
+    BOTTOM("bottom"),
+    ;
+
+    override val attributeName: String
+        get() = "position"
 }
 
 /**
@@ -119,30 +124,27 @@ open class Tabbar(
         return render("ons-tabbar", childrenVNodes())
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
-        tabPosition?.let {
-            sn.add("position" to it.type)
-        }
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
+        attributeSetBuilder.add(tabPosition)
         if (animation == false) {
-            sn.add("animation" to "none")
+            attributeSetBuilder.add("animation", "none")
         }
         if (swipeable == true) {
-            sn.add("swipeable" to "swipeable")
+            attributeSetBuilder.add("swipeable")
         }
         ignoreEdgeWidth?.let {
-            sn.add("ignore-edge-width" to "${it}px")
+            attributeSetBuilder.add("ignore-edge-width", "${it}px")
         }
         if (hideTabs == true) {
-            sn.add("hide-tabs" to "hide-tabs")
+            attributeSetBuilder.add("hide-tabs")
         }
         if (tabBorder == true) {
-            sn.add("tab-border" to "tab-border")
+            attributeSetBuilder.add("tab-border")
         }
         modifier?.let {
-            sn.add("modifier" to it)
+            attributeSetBuilder.add("modifier", it)
         }
-        return sn
     }
 
     @Suppress("UnsafeCastFromDynamic")

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/toolbar/BottomToolbar.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/toolbar/BottomToolbar.kt
@@ -23,7 +23,7 @@
 package pl.treksoft.kvision.onsenui.toolbar
 
 import com.github.snabbdom.VNode
-import pl.treksoft.kvision.core.StringPair
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.onsenui.core.Page
 import pl.treksoft.kvision.panel.SimplePanel
 import pl.treksoft.kvision.utils.set
@@ -54,12 +54,11 @@ open class BottomToolbar(
         return render("ons-bottom-toolbar", childrenVNodes())
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         modifier?.let {
-            sn.add("modifier" to it)
+            attributeSetBuilder.add("modifier", it)
         }
-        return sn
     }
 }
 

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/toolbar/Toolbar.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/toolbar/Toolbar.kt
@@ -23,7 +23,7 @@
 package pl.treksoft.kvision.onsenui.toolbar
 
 import com.github.snabbdom.VNode
-import pl.treksoft.kvision.core.StringPair
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.html.Div
 import pl.treksoft.kvision.onsenui.core.Page
 import pl.treksoft.kvision.panel.SimplePanel
@@ -113,18 +113,17 @@ open class Toolbar(
         rightPanel.builder()
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         if (inline == true) {
-            sn.add("inline" to "inline")
+            attributeSetBuilder.add("inline")
         }
         if (static == true) {
-            sn.add("static" to "static")
+            attributeSetBuilder.add("static")
         }
         modifier?.let {
-            sn.add("modifier" to it)
+            attributeSetBuilder.add("modifier", it)
         }
-        return sn
     }
 
     /**

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/toolbar/ToolbarButton.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/toolbar/ToolbarButton.kt
@@ -23,8 +23,8 @@
 package pl.treksoft.kvision.onsenui.toolbar
 
 import org.w3c.dom.events.MouseEvent
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.ClassSetBuilder
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.html.Align
 import pl.treksoft.kvision.html.CustomTag
 import pl.treksoft.kvision.html.Div
@@ -79,18 +79,17 @@ open class ToolbarButton(
         @Suppress("UnsafeCastFromDynamic")
         get() = getElement()?.asDynamic()?.disabled
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         icon?.let {
-            sn.add("icon" to it)
+            attributeSetBuilder.add("icon", it)
         }
         if (disabled == true) {
-            sn.add("disabled" to "disabled")
+            attributeSetBuilder.add("disabled")
         }
         modifier?.let {
-            sn.add("modifier" to it)
+            attributeSetBuilder.add("modifier", it)
         }
-        return sn
     }
 
     override fun buildClassSet(classSetBuilder: ClassSetBuilder) {

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/visual/Card.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/visual/Card.kt
@@ -23,8 +23,8 @@
 package pl.treksoft.kvision.onsenui.visual
 
 import com.github.snabbdom.VNode
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.html.Div
 import pl.treksoft.kvision.panel.SimplePanel
 import pl.treksoft.kvision.state.ObservableState
@@ -57,12 +57,11 @@ open class Card(
         return render("ons-card", childrenVNodes())
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         modifier?.let {
-            sn.add("modifier" to it)
+            attributeSetBuilder.add("modifier", it)
         }
-        return sn
     }
 
     /**

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/visual/Icon.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/visual/Icon.kt
@@ -23,8 +23,8 @@
 package pl.treksoft.kvision.onsenui.visual
 
 import com.github.snabbdom.VNode
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.utils.set
 
@@ -84,22 +84,21 @@ open class Icon(
         return render("ons-icon")
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
-        sn.add("icon" to icon)
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
+        attributeSetBuilder.add("icon", icon)
         size?.let {
-            sn.add("size" to it)
+            attributeSetBuilder.add("size", it)
         }
         rotate?.let {
-            sn.add("rotate" to "$it")
+            attributeSetBuilder.add("rotate", "$it")
         }
         if (fixedWidth == true) {
-            sn.add("fixed-width" to "fixed-width")
+            attributeSetBuilder.add("fixed-width")
         }
         if (spin == true) {
-            sn.add("spin" to "spin")
+            attributeSetBuilder.add("spin")
         }
-        return sn
     }
 }
 

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/visual/ProgressBar.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/visual/ProgressBar.kt
@@ -23,8 +23,8 @@
 package pl.treksoft.kvision.onsenui.visual
 
 import com.github.snabbdom.VNode
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.state.ObservableState
 import pl.treksoft.kvision.state.bind
@@ -77,21 +77,20 @@ open class ProgressBar(
         return render("ons-progress-bar")
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         value?.let {
-            sn.add("value" to "$it")
+            attributeSetBuilder.add("value", "$it")
         }
         secondaryValue?.let {
-            sn.add("secondary-value" to "$it")
+            attributeSetBuilder.add("secondary-value", "$it")
         }
         if (indeterminate == true) {
-            sn.add("indeterminate" to "indeterminate")
+            attributeSetBuilder.add("indeterminate")
         }
         modifier?.let {
-            sn.add("modifier" to it)
+            attributeSetBuilder.add("modifier", it)
         }
-        return sn
     }
 }
 

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/visual/ProgressCircular.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/visual/ProgressCircular.kt
@@ -23,8 +23,8 @@
 package pl.treksoft.kvision.onsenui.visual
 
 import com.github.snabbdom.VNode
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.state.ObservableState
 import pl.treksoft.kvision.state.bind
@@ -77,21 +77,20 @@ open class ProgressCircular(
         return render("ons-progress-circular")
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         value?.let {
-            sn.add("value" to "$it")
+            attributeSetBuilder.add("value", "$it")
         }
         secondaryValue?.let {
-            sn.add("secondary-value" to "$it")
+            attributeSetBuilder.add("secondary-value", "$it")
         }
         if (indeterminate == true) {
-            sn.add("indeterminate" to "indeterminate")
+            attributeSetBuilder.add("indeterminate")
         }
         modifier?.let {
-            sn.add("modifier" to it)
+            attributeSetBuilder.add("modifier", it)
         }
-        return sn
     }
 }
 

--- a/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/visual/Ripple.kt
+++ b/kvision-modules/kvision-onsenui/src/main/kotlin/pl/treksoft/kvision/onsenui/visual/Ripple.kt
@@ -23,15 +23,20 @@
 package pl.treksoft.kvision.onsenui.visual
 
 import com.github.snabbdom.VNode
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.Color
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringPair
+import pl.treksoft.kvision.core.DomAttribute
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.utils.set
 
-enum class RippleSize(internal val type: String) {
+enum class RippleSize(override val attributeValue: String) : DomAttribute {
     COVER("cover"),
-    CONTAIN("contain")
+    CONTAIN("contain"),
+    ;
+
+    override val attributeName: String
+        get() = "size"
 }
 
 /**
@@ -93,27 +98,24 @@ open class Ripple(
         return render("ons-ripple")
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         rippleColor?.let {
-            sn.add("color" to it.asString())
+            attributeSetBuilder.add("color", it.asString())
         }
         rippleBackground?.let {
-            sn.add("background" to it.asString())
+            attributeSetBuilder.add("background", it.asString())
         }
-        size?.let {
-            sn.add("size" to it.type)
-        }
+        attributeSetBuilder.add(size)
         if (center == true) {
-            sn.add("center" to "center")
+            attributeSetBuilder.add("center")
         }
         modifier?.let {
-            sn.add("modifier" to it)
+            attributeSetBuilder.add("modifier", it)
         }
         if (disabled == true) {
-            sn.add("disabled" to "disabled")
+            attributeSetBuilder.add("disabled")
         }
-        return sn
     }
 }
 

--- a/kvision-modules/kvision-richtext/src/main/kotlin/pl/treksoft/kvision/form/text/RichTextInput.kt
+++ b/kvision-modules/kvision-richtext/src/main/kotlin/pl/treksoft/kvision/form/text/RichTextInput.kt
@@ -25,8 +25,8 @@ import com.github.snabbdom.VNode
 import kotlinx.browser.document
 import pl.treksoft.jquery.invoke
 import pl.treksoft.jquery.jQuery
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.state.ObservableState
 import pl.treksoft.kvision.state.bind
 import pl.treksoft.kvision.utils.set
@@ -46,23 +46,22 @@ open class RichTextInput(value: String? = null, classes: Set<String> = setOf()) 
         return render("trix-editor")
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         placeholder?.let {
-            sn.add("placeholder" to translate(it))
+            attributeSetBuilder.add("placeholder", translate(it))
         }
         name?.let {
-            sn.add("name" to it)
+            attributeSetBuilder.add("name", it)
         }
         autofocus?.let {
             if (it) {
-                sn.add("autofocus" to "autofocus")
+                attributeSetBuilder.add("autofocus")
             }
         }
         if (disabled) {
-            sn.add("disabled" to "disabled")
+            attributeSetBuilder.add("disabled")
         }
-        return sn
     }
 
     @Suppress("UnsafeCastFromDynamic", "ComplexMethod")

--- a/src/main/kotlin/pl/treksoft/kvision/core/AttributeSetBuilder.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/core/AttributeSetBuilder.kt
@@ -1,0 +1,34 @@
+package pl.treksoft.kvision.core
+
+import com.github.snabbdom.Attrs
+import pl.treksoft.kvision.utils.snAttrs
+
+interface AttributeSetBuilder {
+    fun add(name: String, value: String = name)
+    fun addAll(attributes: Map<String, String>) {
+        attributes.forEach { (key, value) -> add(key, value) }
+    }
+    fun add(attribute: DomAttribute?) {
+        if (attribute != null) {
+            add(attribute.attributeName, attribute.attributeValue)
+        }
+    }
+}
+
+internal class AttributeSetBuilderImpl : AttributeSetBuilder {
+    val attributes: Attrs
+        get() = snAttrs(_attributes)
+
+    private val _attributes: MutableMap<String, String> = HashMap()
+
+    override fun add(name: String, value: String) {
+        _attributes.put(name, value)
+    }
+
+    override fun addAll(attributes: Map<String, String>) {
+        this._attributes.putAll(attributes)
+    }
+}
+
+fun buildAttributeSet(delegate: (builder: AttributeSetBuilder) -> Unit): Attrs =
+    AttributeSetBuilderImpl().also { delegate(it) }.attributes

--- a/src/main/kotlin/pl/treksoft/kvision/core/ClassSetBuilder.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/core/ClassSetBuilder.kt
@@ -23,6 +23,9 @@
 
 package pl.treksoft.kvision.core
 
+import com.github.snabbdom.Classes
+import pl.treksoft.kvision.utils.snClasses
+
 /**
  * A builder in order to create a set of CSS-classes
  */
@@ -39,8 +42,8 @@ interface ClassSetBuilder {
 }
 
 internal class ClassSetBuilderImpl : ClassSetBuilder {
-    val classes: Set<String>
-        get() = HashSet(_classes)
+    val classes: Classes
+        get() = snClasses(_classes)
 
     private val _classes: MutableSet<String> = HashSet()
 
@@ -53,5 +56,5 @@ internal class ClassSetBuilderImpl : ClassSetBuilder {
     }
 }
 
-fun buildClassSet(delegate: (builder: ClassSetBuilder) -> Unit): Set<String> =
+fun buildClassSet(delegate: (builder: ClassSetBuilder) -> Unit): Classes =
     ClassSetBuilderImpl().also { delegate(it) }.classes

--- a/src/main/kotlin/pl/treksoft/kvision/core/DomAttribute.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/core/DomAttribute.kt
@@ -1,0 +1,6 @@
+package pl.treksoft.kvision.core
+
+interface DomAttribute {
+    val attributeName: String
+    val attributeValue: String
+}

--- a/src/main/kotlin/pl/treksoft/kvision/form/FieldLabel.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/form/FieldLabel.kt
@@ -21,8 +21,8 @@
  */
 package pl.treksoft.kvision.form
 
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.html.TAG
 import pl.treksoft.kvision.html.Tag
 import pl.treksoft.kvision.state.ObservableState
@@ -46,8 +46,9 @@ open class FieldLabel(
     content, rich, classes = classes
 ) {
 
-    override fun getSnAttrs(): List<StringPair> {
-        return super.getSnAttrs() + ("for" to forId)
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
+        attributeSetBuilder.add("for", forId)
     }
 }
 

--- a/src/main/kotlin/pl/treksoft/kvision/form/FormPanel.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/form/FormPanel.kt
@@ -24,9 +24,10 @@ package pl.treksoft.kvision.form
 import com.github.snabbdom.VNode
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.serializer
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringPair
+import pl.treksoft.kvision.core.DomAttribute
 import pl.treksoft.kvision.form.FormPanel.Companion.create
 import pl.treksoft.kvision.html.Div
 import pl.treksoft.kvision.panel.FieldsetPanel
@@ -66,9 +67,13 @@ enum class FormHorizontalRatio(val labels: Int, val fields: Int) {
 /**
  * Form methods.
  */
-enum class FormMethod(internal val method: String) {
+enum class FormMethod(override val attributeValue: String) : DomAttribute {
     GET("get"),
-    POST("post")
+    POST("post"),
+    ;
+
+    override val attributeName: String
+        get() = "method"
 }
 
 /**
@@ -83,11 +88,15 @@ enum class FormEnctype(internal val enctype: String) {
 /**
  * Form targets.
  */
-enum class FormTarget(internal val target: String) {
+enum class FormTarget(override val attributeValue: String) : DomAttribute {
     BLANK("_blank"),
     SELF("_self"),
     PARENT("_parent"),
-    TOP("_top")
+    TOP("_top"),
+    ;
+
+    override val attributeName: String
+        get() = "target"
 }
 
 /**
@@ -219,30 +228,25 @@ open class FormPanel<K : Any>(
         if (condensed) classSetBuilder.add("kv-form-condensed")
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
-        method?.let {
-            sn.add("method" to it.method)
-        }
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
+        attributeSetBuilder.add(method)
         action?.let {
-            sn.add("action" to it)
+            attributeSetBuilder.add("action", it)
         }
         enctype?.let {
-            sn.add("enctype" to it.enctype)
+            attributeSetBuilder.add("enctype", it.enctype)
         }
         name?.let {
-            sn.add("name" to it)
+            attributeSetBuilder.add("name", it)
         }
-        target?.let {
-            sn.add("target" to it.target)
-        }
+        attributeSetBuilder.add(target)
         if (autocomplete == false) {
-            sn.add("autocomplete" to "off")
+            attributeSetBuilder.add("autocomplete", "off")
         }
         if (novalidate == true) {
-            sn.add("novalidate" to "novalidate")
+            attributeSetBuilder.add("novalidate")
         }
-        return sn
     }
 
     protected fun <C : FormControl> addInternal(

--- a/src/main/kotlin/pl/treksoft/kvision/form/check/CheckInput.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/form/check/CheckInput.kt
@@ -23,8 +23,8 @@ package pl.treksoft.kvision.form.check
 
 import com.github.snabbdom.VNode
 import org.w3c.dom.events.MouseEvent
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.ClassSetBuilder
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.form.FormInput
 import pl.treksoft.kvision.form.InputSize
@@ -120,22 +120,21 @@ abstract class CheckInput(
         classSetBuilder.add(size)
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
-        sn.add("type" to type.type)
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
+        attributeSetBuilder.add("type", type.type)
         if (startValue) {
-            sn.add("checked" to "checked")
+            attributeSetBuilder.add("checked")
         }
         name?.let {
-            sn.add("name" to it)
+            attributeSetBuilder.add("name", it)
         }
         if (disabled) {
-            sn.add("disabled" to "disabled")
+            attributeSetBuilder.add("disabled")
         }
         extraValue?.let {
-            sn.add("value" to it)
+            attributeSetBuilder.add("value", it)
         }
-        return sn
     }
 
     override fun afterInsert(node: VNode) {

--- a/src/main/kotlin/pl/treksoft/kvision/form/range/RangeInput.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/form/range/RangeInput.kt
@@ -23,9 +23,9 @@ package pl.treksoft.kvision.form.range
 
 import com.github.snabbdom.VNode
 import org.w3c.dom.HTMLInputElement
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.form.FormInput
 import pl.treksoft.kvision.form.InputSize
@@ -129,32 +129,31 @@ open class RangeInput(
         classSetBuilder.add(size)
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
-        sn.add("type" to "range")
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
+        attributeSetBuilder.add("type", "range")
         startValue?.let {
-            sn.add("value" to "$it")
+            attributeSetBuilder.add("value", "$it")
         }
         name?.let {
-            sn.add("name" to it)
+            attributeSetBuilder.add("name", it)
         }
-        sn.add("min" to "$min")
-        sn.add("max" to "$max")
-        sn.add("step" to "$step")
+        attributeSetBuilder.add("min", "$min")
+        attributeSetBuilder.add("max", "$max")
+        attributeSetBuilder.add("step", "$step")
         autofocus?.let {
             if (it) {
-                sn.add("autofocus" to "autofocus")
+                attributeSetBuilder.add("autofocus")
             }
         }
         readonly?.let {
             if (it) {
-                sn.add("readonly" to "readonly")
+                attributeSetBuilder.add("readonly")
             }
         }
         if (disabled) {
-            sn.add("disabled" to "disabled")
+            attributeSetBuilder.add("disabled")
         }
-        return sn
     }
 
     override fun afterInsert(node: VNode) {

--- a/src/main/kotlin/pl/treksoft/kvision/form/select/SimpleSelectInput.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/form/select/SimpleSelectInput.kt
@@ -22,6 +22,7 @@
 package pl.treksoft.kvision.form.select
 
 import com.github.snabbdom.VNode
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Container
 import pl.treksoft.kvision.core.StringPair
@@ -206,26 +207,25 @@ open class SimpleSelectInput(
         classSetBuilder.add(size)
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         name?.let {
-            sn.add("name" to it)
+            attributeSetBuilder.add("name", it)
         }
         if (multiple) {
-            sn.add("multiple" to "multiple")
+            attributeSetBuilder.add("multiple")
         }
         selectSize?.let {
-            sn.add("size" to "$it")
+            attributeSetBuilder.add("size", "$it")
         }
         autofocus?.let {
             if (it) {
-                sn.add("autofocus" to "autofocus")
+                attributeSetBuilder.add("autofocus")
             }
         }
         if (disabled) {
-            sn.add("disabled" to "disabled")
+            attributeSetBuilder.add("disabled")
         }
-        return sn
     }
 
     override fun afterInsert(node: VNode) {

--- a/src/main/kotlin/pl/treksoft/kvision/form/text/AbstractTextInput.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/form/text/AbstractTextInput.kt
@@ -22,8 +22,8 @@
 package pl.treksoft.kvision.form.text
 
 import com.github.snabbdom.VNode
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.ClassSetBuilder
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.form.FormInput
 import pl.treksoft.kvision.form.InputSize
@@ -111,32 +111,31 @@ abstract class AbstractTextInput(
         classSetBuilder.add(size)
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         placeholder?.let {
-            sn.add("placeholder" to translate(it))
+            attributeSetBuilder.add("placeholder", translate(it))
         }
         name?.let {
-            sn.add("name" to it)
+            attributeSetBuilder.add("name", it)
         }
         autofocus?.let {
             if (it) {
-                sn.add("autofocus" to "autofocus")
+                attributeSetBuilder.add("autofocus")
             }
         }
         maxlength?.let {
-            sn.add("maxlength" to ("" + it))
+            attributeSetBuilder.add("maxlength", ("" + it))
         }
         readonly?.let {
             if (it) {
-                sn.add("readonly" to "readonly")
+                attributeSetBuilder.add("readonly")
             }
         }
         if (disabled) {
-            sn.add("disabled" to "disabled")
+            attributeSetBuilder.add("disabled")
         }
-        return sn
-    }
+            }
 
     override fun afterInsert(node: VNode) {
         refreshState()

--- a/src/main/kotlin/pl/treksoft/kvision/form/text/TextAreaInput.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/form/text/TextAreaInput.kt
@@ -22,8 +22,8 @@
 package pl.treksoft.kvision.form.text
 
 import com.github.snabbdom.VNode
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.state.ObservableState
 import pl.treksoft.kvision.state.bind
 import pl.treksoft.kvision.utils.set
@@ -61,18 +61,17 @@ open class TextAreaInput(cols: Int? = null, rows: Int? = null, value: String? = 
         } ?: render("textarea")
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         cols?.let {
-            sn.add("cols" to ("" + it))
+            attributeSetBuilder.add("cols", ("" + it))
         }
         rows?.let {
-            sn.add("rows" to ("" + it))
+            attributeSetBuilder.add("rows", ("" + it))
         }
         if (wrapHard) {
-            sn.add("wrap" to "hard")
+            attributeSetBuilder.add("wrap", "hard")
         }
-        return sn
     }
 }
 

--- a/src/main/kotlin/pl/treksoft/kvision/form/text/TextInput.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/form/text/TextInput.kt
@@ -22,8 +22,8 @@
 package pl.treksoft.kvision.form.text
 
 import com.github.snabbdom.VNode
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.state.ObservableState
 import pl.treksoft.kvision.state.bind
 import pl.treksoft.kvision.utils.set
@@ -66,20 +66,15 @@ open class TextInput(type: TextInputType = TextInputType.TEXT, value: String? = 
         return render("input")
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
-        sn.add("type" to type.type)
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
+        attributeSetBuilder.add("type", type.type)
         startValue?.let {
-            sn.add("value" to it)
+            attributeSetBuilder.add("value", it)
         }
         autocomplete?.let {
-            if (it) {
-                sn.add("autocomplete" to "on")
-            } else {
-                sn.add("autocomplete" to "off")
-            }
+            attributeSetBuilder.add("autocomplete", if (it) "on" else "off")
         }
-        return sn
     }
 }
 

--- a/src/main/kotlin/pl/treksoft/kvision/html/Button.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/html/Button.kt
@@ -23,11 +23,11 @@ package pl.treksoft.kvision.html
 
 import com.github.snabbdom.VNode
 import org.w3c.dom.events.MouseEvent
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Container
 import pl.treksoft.kvision.core.CssClass
 import pl.treksoft.kvision.core.ResString
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.panel.SimplePanel
 import pl.treksoft.kvision.state.ObservableState
 import pl.treksoft.kvision.state.bind
@@ -160,13 +160,12 @@ open class Button(
         }
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val snattrs = super.getSnAttrs().toMutableList()
-        snattrs.add("type" to type.buttonType)
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
+        attributeSetBuilder.add("type", type.buttonType)
         if (disabled) {
-            snattrs.add("disabled" to "disabled")
+            attributeSetBuilder.add("disabled")
         }
-        return snattrs
     }
 
     /**

--- a/src/main/kotlin/pl/treksoft/kvision/html/Canvas.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/html/Canvas.kt
@@ -24,8 +24,8 @@ package pl.treksoft.kvision.html
 import com.github.snabbdom.VNode
 import org.w3c.dom.CanvasRenderingContext2D
 import org.w3c.dom.HTMLCanvasElement
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.state.ObservableState
 import pl.treksoft.kvision.state.bind
@@ -61,15 +61,14 @@ open class Canvas(
         return render("canvas")
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val pr = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         canvasWidth?.let {
-            pr.add("width" to "$it")
+            attributeSetBuilder.add("width", "$it")
         }
         canvasHeight?.let {
-            pr.add("height" to "$it")
+            attributeSetBuilder.add("height", "$it")
         }
-        return pr
     }
 
     override fun afterInsertInternal(node: VNode) {

--- a/src/main/kotlin/pl/treksoft/kvision/html/Iframe.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/html/Iframe.kt
@@ -23,8 +23,8 @@ package pl.treksoft.kvision.html
 
 import com.github.snabbdom.VNode
 import org.w3c.dom.Window
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.state.ObservableState
 import pl.treksoft.kvision.state.bind
@@ -101,27 +101,26 @@ open class Iframe(
         return render("iframe")
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val pr = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         src?.let {
-            pr.add("src" to it)
+            attributeSetBuilder.add("src", it)
         }
         srcdoc?.let {
-            pr.add("srcdoc" to it)
+            attributeSetBuilder.add("srcdoc", it)
         }
         name?.let {
-            pr.add("name" to it)
+            attributeSetBuilder.add("name", it)
         }
         iframeWidth?.let {
-            pr.add("width" to "$it")
+            attributeSetBuilder.add("width", "$it")
         }
         iframeHeight?.let {
-            pr.add("height" to "$it")
+            attributeSetBuilder.add("height", "$it")
         }
         sandbox?.let {
-            pr.add("sandbox" to it.joinToString(" ") { it.option })
+            attributeSetBuilder.add("sandbox", it.joinToString(" ") { it.option })
         }
-        return pr
     }
 
     @Suppress("UnsafeCastFromDynamic")

--- a/src/main/kotlin/pl/treksoft/kvision/html/Image.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/html/Image.kt
@@ -22,11 +22,11 @@
 package pl.treksoft.kvision.html
 
 import com.github.snabbdom.VNode
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.ClassSetBuilder
 import pl.treksoft.kvision.core.Container
 import pl.treksoft.kvision.core.CssClass
 import pl.treksoft.kvision.core.ResString
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.state.ObservableState
 import pl.treksoft.kvision.state.bind
@@ -85,15 +85,14 @@ open class Image(
         return render("img")
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val pr = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         src?.let {
-            pr.add("src" to it)
+            attributeSetBuilder.add("src", it)
         }
         alt?.let {
-            pr.add("alt" to translate(it))
+            attributeSetBuilder.add("alt", translate(it))
         }
-        return pr
     }
 
     override fun buildClassSet(classSetBuilder: ClassSetBuilder) {

--- a/src/main/kotlin/pl/treksoft/kvision/html/Label.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/html/Label.kt
@@ -21,8 +21,8 @@
  */
 package pl.treksoft.kvision.html
 
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.Container
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.state.ObservableState
 import pl.treksoft.kvision.state.bind
 import pl.treksoft.kvision.utils.set
@@ -53,12 +53,11 @@ open class Label(
         init?.invoke(this)
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val sn = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         forId?.let {
-            sn.add("for" to it)
+            attributeSetBuilder.add("for", it)
         }
-        return sn
     }
 }
 

--- a/src/main/kotlin/pl/treksoft/kvision/html/Link.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/html/Link.kt
@@ -23,9 +23,9 @@ package pl.treksoft.kvision.html
 
 import com.github.snabbdom.VNode
 import org.w3c.dom.events.MouseEvent
+import pl.treksoft.kvision.core.AttributeSetBuilder
 import pl.treksoft.kvision.core.Container
 import pl.treksoft.kvision.core.ResString
-import pl.treksoft.kvision.core.StringPair
 import pl.treksoft.kvision.panel.SimplePanel
 import pl.treksoft.kvision.state.ObservableState
 import pl.treksoft.kvision.state.bind
@@ -93,15 +93,14 @@ open class Link(
         }
     }
 
-    override fun getSnAttrs(): List<StringPair> {
-        val pr = super.getSnAttrs().toMutableList()
+    override fun buildAttributesSet(attributeSetBuilder: AttributeSetBuilder) {
+        super.buildAttributesSet(attributeSetBuilder)
         url?.let {
-            pr.add("href" to it)
+            attributeSetBuilder.add("href", it)
         }
         target?.let {
-            pr.add("target" to it)
+            attributeSetBuilder.add("target", it)
         }
-        return pr
     }
 
     /**

--- a/src/main/kotlin/pl/treksoft/kvision/state/StateBinding.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/state/StateBinding.kt
@@ -41,10 +41,8 @@ class StateBinding<S : Any, CONT : Container, CONTENT>(
     private val factory: (CONT.(S) -> CONTENT)
 ) : Widget(setOf()) {
 
-    private val unsubscribe: () -> Unit
-
     init {
-        unsubscribe = observableState.subscribe { update(it) }
+        addAfterDisposeHook(observableState.subscribe(this::update))
     }
 
     private var updateState: ((S, CONTENT) -> Unit)? = null
@@ -70,11 +68,6 @@ class StateBinding<S : Any, CONT : Container, CONTENT>(
 
     internal fun setUpdateState(updateState: (S, CONTENT) -> Unit) {
         this.updateState = updateState
-    }
-
-    override fun dispose() {
-        unsubscribe()
-        super.dispose()
     }
 }
 

--- a/src/main/kotlin/pl/treksoft/kvision/utils/Snabbdom.kt
+++ b/src/main/kotlin/pl/treksoft/kvision/utils/Snabbdom.kt
@@ -318,3 +318,10 @@ inline fun snAttrs(pairs: List<StringPair>): Attrs {
         pairs.forEach { (key, value) -> this[key] = value }
     }
 }
+
+@Suppress("UnsafeCastFromDynamic", "NOTHING_TO_INLINE")
+inline fun snAttrs(pairs: Map<String, String>): Attrs {
+    return obj {
+        pairs.forEach { (key, value) -> this[key] = value }
+    }
+}

--- a/src/test/kotlin/test/pl/treksoft/kvision/TestUtil.kt
+++ b/src/test/kotlin/test/pl/treksoft/kvision/TestUtil.kt
@@ -25,9 +25,9 @@ import kotlinx.browser.document
 import org.w3c.dom.Element
 import org.w3c.dom.asList
 import pl.treksoft.jquery.JQuery
-import pl.treksoft.jquery.jQuery
-import pl.treksoft.jquery.invoke
 import pl.treksoft.jquery.get
+import pl.treksoft.jquery.invoke
+import pl.treksoft.jquery.jQuery
 import pl.treksoft.kvision.core.Widget
 import pl.treksoft.kvision.panel.Root
 import kotlin.test.assertEquals
@@ -112,5 +112,13 @@ interface WSpec : DomSpec {
     }
 
 }
+
+fun toKeyValuePairString(obj: dynamic) =
+    js("Object")
+        .entries(obj)
+        .unsafeCast<Array<Array<Any?>>>()
+        .map { pair -> pair.map { it.toString() } }
+        .apply { sortedBy { it[0] } }
+        .joinToString(",") { it.joinToString("=") }
 
 external fun require(name: String): dynamic

--- a/src/test/kotlin/test/pl/treksoft/kvision/core/AttributeSetBuilderImplSpec.kt
+++ b/src/test/kotlin/test/pl/treksoft/kvision/core/AttributeSetBuilderImplSpec.kt
@@ -1,0 +1,67 @@
+package test.pl.treksoft.kvision.core
+
+import com.github.snabbdom.Attrs
+import pl.treksoft.kvision.core.AttributeSetBuilderImpl
+import pl.treksoft.kvision.core.buildAttributeSet
+import test.pl.treksoft.kvision.toKeyValuePairString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AttributeSetBuilderImplSpec {
+    @Test
+    fun addNothing_returnsEmptyMap() {
+        // execution
+        val actual: Attrs = AttributeSetBuilderImpl().attributes
+
+        // evaluation
+        assertEquals("", toKeyValuePairString(actual))
+    }
+
+    @Test
+    fun add_addsValueToSet() {
+        // execution
+        val actual: Attrs = AttributeSetBuilderImpl().also {
+            it.add("key1")
+            it.add("key2", "value2")
+        }.attributes
+
+        // evaluation
+        assertEquals("key1=key1,key2=value2", toKeyValuePairString(actual))
+    }
+
+    @Test
+    fun addAll_addsValuesToSet() {
+        // execution
+        val actual: Attrs = AttributeSetBuilderImpl().also {
+            it.addAll(mapOf("key1" to "value1", "key2" to "value2"))
+        }.attributes
+
+        // evaluation
+        assertEquals("key1=value1,key2=value2", toKeyValuePairString(actual))
+    }
+
+    @Test
+    fun addAfterQueryingValue_doesNotChanceValue() {
+        // setup
+        val builder = AttributeSetBuilderImpl()
+        builder.add("value1")
+
+        // execution
+        val actual: Attrs = builder.attributes
+        builder.add("value2")
+
+        // evaluation
+        assertEquals("value1=value1", toKeyValuePairString(actual))
+    }
+
+    @Test
+    fun buildAttributeSet_buildsUsingSuppliedFunction() {
+        // execution
+        val actual: Attrs = buildAttributeSet { it.add("value") }
+
+        // evaluation
+        assertEquals("value=value", toKeyValuePairString(actual))
+    }
+}
+
+

--- a/src/test/kotlin/test/pl/treksoft/kvision/core/ClassSetBuilderImplSpec.kt
+++ b/src/test/kotlin/test/pl/treksoft/kvision/core/ClassSetBuilderImplSpec.kt
@@ -24,9 +24,10 @@
 package test.pl.treksoft.kvision.core
 
 import pl.treksoft.kvision.core.ClassSetBuilderImpl
+import pl.treksoft.kvision.core.buildClassSet
+import test.pl.treksoft.kvision.toKeyValuePairString
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 class ClassSetBuilderImplSpec {
     @Test
@@ -35,7 +36,7 @@ class ClassSetBuilderImplSpec {
         val actual = ClassSetBuilderImpl().classes
 
         // evaluation
-        assertEquals(actual.sorted().joinToString(), "")
+        assertEquals("", toKeyValuePairString(actual), "")
     }
 
     @Test
@@ -47,7 +48,7 @@ class ClassSetBuilderImplSpec {
         }.classes
 
         // evaluation
-        assertEquals("value1,value2", actual.sorted().joinToString(","))
+        assertEquals("value1=true,value2=true", toKeyValuePairString(actual))
     }
 
     @Test
@@ -58,7 +59,7 @@ class ClassSetBuilderImplSpec {
         }.classes
 
         // evaluation
-        assertEquals("value1,value2", actual.sorted().joinToString(","))
+        assertEquals("value1=true,value2=true", toKeyValuePairString(actual))
     }
 
     @Test
@@ -72,6 +73,18 @@ class ClassSetBuilderImplSpec {
         builder.add("value2")
 
         // evaluation
-        assertEquals("value1", actual.sorted().joinToString(","))
+        assertEquals("value1=true", toKeyValuePairString(actual))
+    }
+
+    @Test
+    fun buildClassSet_buildsClassesUsingGivenFunction() {
+        // execution
+        val actual = buildClassSet {
+            it.add("value1")
+            it.add("value2")
+        }
+
+        // evaluation
+        assertEquals("value1=true,value2=true", toKeyValuePairString(actual))
     }
 }

--- a/src/test/kotlin/test/pl/treksoft/kvision/core/SingleObjectCacheSpec.kt
+++ b/src/test/kotlin/test/pl/treksoft/kvision/core/SingleObjectCacheSpec.kt
@@ -24,13 +24,14 @@
 package test.pl.treksoft.kvision.core
 
 import pl.treksoft.kvision.core.LazyCache
+import pl.treksoft.kvision.core.SingleObjectCache
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class LazyCacheSpec {
+class SingleObjectCacheSpec {
     private var invocationCount = 0
-    private lateinit var lazyCache: LazyCache<Int>
+    private lateinit var lazyCache: SingleObjectCache<Int>
 
     @BeforeTest
     fun setUp() {
@@ -87,5 +88,33 @@ class LazyCacheSpec {
 
         // evaluation
         assertEquals(invocationCount, 0, "invocation count")
+    }
+
+    @Test
+    fun clearOn_clearsIfFunctionReturnsTrue() {
+        // setup
+        val value1 = lazyCache.value
+
+        // execution
+        val value2 = lazyCache.clearOn { true }.value
+
+        // evaluation
+        assertEquals(value1, 10, "returned value 1")
+        assertEquals(value2, 11, "returned value 2")
+        assertEquals(invocationCount, 2, "invocation count")
+    }
+
+    @Test
+    fun clearOn_doesNotClearIfFunctionReturnsFalse() {
+        // setup
+        val value1 = lazyCache.value
+
+        // execution
+        val value2 = lazyCache.clearOn { false }.value
+
+        // evaluation
+        assertEquals(value1, 10, "returned value 1")
+        assertEquals(value2, 10, "returned value 2")
+        assertEquals(invocationCount, 1, "invocation count")
     }
 }


### PR DESCRIPTION
Same as #199, but this time for attributes.

Also in the class `ClassSetBuilderImpl` I created a copy of the set of classes. From an API perspective I believe that this makes sense, however all that happens, is that a short moment after yer another copy is created in form of a Snabbdom `Classes` object. I was hesitant to couple the `ClassSetBuilderImpl` so close to Snabbdom at first, however since this is an `internal` class which only exposes those parts that are included in the defining interface, and the mentioned part is not part of that public API, I believe that this is not an issue. So for the `AttributeSetBuilderImpl` I immediately create Snabbdom objects and I also refactored `ClassSetBuilderImpl` to do the same.