### PR TITLE
KVServiceManager extract objectMapper creation & request mapping registry

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,6 +25,8 @@ reduxKotlinVersion=0.5.5
 reduxKotlinThunkVersion=0.5.5
 mpaptRuntimeVersion=0.8.7
 systemProp.npmPublishVersion=1.0.4
+testNgVersion=7.3.0
+hamcrestVersion=2.2
 
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 org.gradle.jvmargs=-Xmx4g

--- a/kvision-modules/kvision-common-remote/build.gradle.kts
+++ b/kvision-modules/kvision-common-remote/build.gradle.kts
@@ -29,6 +29,7 @@ kotlin {
         }
         val jvmMain by getting {
             dependencies {
+                api(project(":kvision-modules:kvision-common-types"))
                 implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonModuleKotlinVersion")
             }
         }

--- a/kvision-modules/kvision-common-remote/src/commonMain/kotlin/pl/treksoft/kvision/remote/RemoteTypes.kt
+++ b/kvision-modules/kvision-common-remote/src/commonMain/kotlin/pl/treksoft/kvision/remote/RemoteTypes.kt
@@ -28,7 +28,16 @@ enum class HttpMethod {
     POST,
     PUT,
     DELETE,
-    OPTIONS
+    OPTIONS,
+    ;
+    companion object {
+        fun fromStringOrNull(txt: String): HttpMethod? =
+            try {
+                valueOf(txt)
+            } catch (e: IllegalArgumentException) {
+                null
+            }
+    }
 }
 
 class ServiceException(message: String) : Exception(message)

--- a/kvision-modules/kvision-common-remote/src/jvmMain/kotlin/pl/treksoft/kvision/remote/ObjectMapperFactory.kt
+++ b/kvision-modules/kvision-common-remote/src/jvmMain/kotlin/pl/treksoft/kvision/remote/ObjectMapperFactory.kt
@@ -1,0 +1,40 @@
+package pl.treksoft.kvision.remote
+
+import com.fasterxml.jackson.databind.module.SimpleModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import pl.treksoft.kvision.types.BigDecimalDeserializer
+import pl.treksoft.kvision.types.BigDecimalSerializer
+import pl.treksoft.kvision.types.LocalDateDeserializer
+import pl.treksoft.kvision.types.LocalDateSerializer
+import pl.treksoft.kvision.types.LocalDateTimeDeserializer
+import pl.treksoft.kvision.types.LocalDateTimeSerializer
+import pl.treksoft.kvision.types.LocalTimeDeserializer
+import pl.treksoft.kvision.types.LocalTimeSerializer
+import pl.treksoft.kvision.types.OffsetDateTimeDeserializer
+import pl.treksoft.kvision.types.OffsetDateTimeSerializer
+import pl.treksoft.kvision.types.OffsetTimeDeserializer
+import pl.treksoft.kvision.types.OffsetTimeSerializer
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.OffsetDateTime
+import java.time.OffsetTime
+
+fun createDefaultObjectMapper() = jacksonObjectMapper().apply {
+    registerModule(SimpleModule().apply {
+        addSerializer(LocalDateTime::class.java, LocalDateTimeSerializer())
+        addSerializer(LocalDate::class.java, LocalDateSerializer())
+        addSerializer(LocalTime::class.java, LocalTimeSerializer())
+        addSerializer(OffsetDateTime::class.java, OffsetDateTimeSerializer())
+        addSerializer(OffsetTime::class.java, OffsetTimeSerializer())
+        addSerializer(BigDecimal::class.java, BigDecimalSerializer())
+
+        addDeserializer(LocalDateTime::class.java, LocalDateTimeDeserializer())
+        addDeserializer(LocalDate::class.java, LocalDateDeserializer())
+        addDeserializer(LocalTime::class.java, LocalTimeDeserializer())
+        addDeserializer(OffsetDateTime::class.java, OffsetDateTimeDeserializer())
+        addDeserializer(OffsetTime::class.java, OffsetTimeDeserializer())
+        addDeserializer(BigDecimal::class.java, BigDecimalDeserializer())
+    })
+}

--- a/kvision-modules/kvision-common-remote/src/jvmMain/kotlin/pl/treksoft/kvision/remote/RouteMapRegistry.kt
+++ b/kvision-modules/kvision-common-remote/src/jvmMain/kotlin/pl/treksoft/kvision/remote/RouteMapRegistry.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2017-present Robert Jaros
+ * Copyright (c) 2020 Yannik Hampe
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package pl.treksoft.kvision.remote
+
+import java.util.*
+import kotlin.collections.HashMap
+import kotlin.reflect.KProperty
+
+/**
+ * Stores a mapping from an HTTP-method+path to a handler
+ */
+interface RouteMapRegistry<T> {
+    fun addRoute(method: HttpMethod, path: String, handler: T)
+    fun findHandler(method: HttpMethod, path: String): T?
+    fun asSequence(method: HttpMethod): Sequence<RouteMapEntry<T>>
+    fun asSequence(): Sequence<RouteMapEntry<T>>
+}
+
+/**
+ * Create a default implementation of @see RouteMapRegistry
+ */
+fun <T> createRouteMapRegistry(): RouteMapRegistry<T> = RouteMapRegistryImpl()
+
+data class RouteMapEntry<T> internal constructor(val method: HttpMethod, val path: String, val handler: T)
+
+private class RouteMapRegistryImpl<T> : RouteMapRegistry<T> {
+    private val map: MutableMap<HttpMethod, MutableMap<String, T>> = EnumMap(HttpMethod::class.java)
+
+    override fun addRoute(method: HttpMethod, path: String, handler: T) {
+        map.compute(method) { _, oldValue ->
+            (oldValue ?: HashMap()).also { it[path] = handler }
+        }
+    }
+
+    override fun findHandler(method: HttpMethod, path: String): T? = map[method]?.let { it[path] }
+
+    override fun asSequence(method: HttpMethod): Sequence<RouteMapEntry<T>> {
+        return (map[method] ?: return emptySequence())
+            .asSequence()
+            .map { (path, handler) -> RouteMapEntry(method, path, handler) }
+    }
+
+    override fun asSequence(): Sequence<RouteMapEntry<T>> =
+        map.asSequence().flatMap { (method, mappings) ->
+            mappings.asSequence().map { RouteMapEntry(method, it.key, it.value) }
+        }
+}
+
+@Deprecated("this is only a helper class for transition of old properties")
+class RouteMapDelegate<T>(val delegate: RouteMapRegistry<T>, val method: HttpMethod) {
+    operator fun getValue(thisRef: Any?, property: KProperty<*>): MutableMap<String, T> =
+        delegate.asSequence(method).associateByTo(HashMap(), RouteMapEntry<T>::path, RouteMapEntry<T>::handler)
+}

--- a/kvision-modules/kvision-server-javalin/src/jvmMain/kotlin/pl/treksoft/kvision/remote/KVServiceManager.kt
+++ b/kvision-modules/kvision-server-javalin/src/jvmMain/kotlin/pl/treksoft/kvision/remote/KVServiceManager.kt
@@ -21,9 +21,6 @@
  */
 package pl.treksoft.kvision.remote
 
-import com.fasterxml.jackson.databind.module.SimpleModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import com.google.inject.Injector
 import io.javalin.Javalin
 import io.javalin.core.security.Role
@@ -42,12 +39,6 @@ import kotlinx.coroutines.launch
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import pl.treksoft.kvision.types.*
-import java.math.BigDecimal
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.LocalTime
-import java.time.OffsetDateTime
-import java.time.OffsetTime
 import kotlin.reflect.KClass
 
 /**
@@ -72,22 +63,7 @@ actual open class KVServiceManager<T : Any> actual constructor(val serviceClass:
     val webSocketRequests: MutableMap<String, (WsHandler) -> Unit> =
         mutableMapOf()
 
-    val mapper = jacksonObjectMapper().apply {
-        val module = SimpleModule()
-        module.addSerializer(LocalDateTime::class.java, LocalDateTimeSerializer())
-        module.addSerializer(LocalDate::class.java, LocalDateSerializer())
-        module.addSerializer(LocalTime::class.java, LocalTimeSerializer())
-        module.addSerializer(OffsetDateTime::class.java, OffsetDateTimeSerializer())
-        module.addSerializer(OffsetTime::class.java, OffsetTimeSerializer())
-        module.addSerializer(BigDecimal::class.java, BigDecimalSerializer())
-        module.addDeserializer(LocalDateTime::class.java, LocalDateTimeDeserializer())
-        module.addDeserializer(LocalDate::class.java, LocalDateDeserializer())
-        module.addDeserializer(LocalTime::class.java, LocalTimeDeserializer())
-        module.addDeserializer(OffsetDateTime::class.java, OffsetDateTimeDeserializer())
-        module.addDeserializer(OffsetTime::class.java, OffsetTimeDeserializer())
-        module.addDeserializer(BigDecimal::class.java, BigDecimalDeserializer())
-        this.registerModule(module)
-    }
+    val mapper = createDefaultObjectMapper()
     var counter: Int = 0
 
     /**

--- a/kvision-modules/kvision-server-jooby/src/jvmMain/kotlin/pl/treksoft/kvision/remote/KVServiceManager.kt
+++ b/kvision-modules/kvision-server-jooby/src/jvmMain/kotlin/pl/treksoft/kvision/remote/KVServiceManager.kt
@@ -21,9 +21,6 @@
  */
 package pl.treksoft.kvision.remote
 
-import com.fasterxml.jackson.databind.module.SimpleModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import com.google.inject.Injector
 import io.jooby.Context
 import io.jooby.CoroutineRouter
@@ -42,12 +39,6 @@ import kotlinx.coroutines.launch
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import pl.treksoft.kvision.types.*
-import java.math.BigDecimal
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.LocalTime
-import java.time.OffsetDateTime
-import java.time.OffsetTime
 import kotlin.reflect.KClass
 
 
@@ -71,22 +62,7 @@ actual open class KVServiceManager<T : Any> actual constructor(val serviceClass:
     val webSocketRequests: MutableMap<String, (ctx: Context, configurer: WebSocketConfigurer) -> Unit> =
         mutableMapOf()
 
-    val mapper = jacksonObjectMapper().apply {
-        val module = SimpleModule()
-        module.addSerializer(LocalDateTime::class.java, LocalDateTimeSerializer())
-        module.addSerializer(LocalDate::class.java, LocalDateSerializer())
-        module.addSerializer(LocalTime::class.java, LocalTimeSerializer())
-        module.addSerializer(OffsetDateTime::class.java, OffsetDateTimeSerializer())
-        module.addSerializer(OffsetTime::class.java, OffsetTimeSerializer())
-        module.addSerializer(BigDecimal::class.java, BigDecimalSerializer())
-        module.addDeserializer(LocalDateTime::class.java, LocalDateTimeDeserializer())
-        module.addDeserializer(LocalDate::class.java, LocalDateDeserializer())
-        module.addDeserializer(LocalTime::class.java, LocalTimeDeserializer())
-        module.addDeserializer(OffsetDateTime::class.java, OffsetDateTimeDeserializer())
-        module.addDeserializer(OffsetTime::class.java, OffsetTimeDeserializer())
-        module.addDeserializer(BigDecimal::class.java, BigDecimalDeserializer())
-        this.registerModule(module)
-    }
+    val mapper = createDefaultObjectMapper()
     var counter: Int = 0
 
     /**

--- a/kvision-modules/kvision-server-jooby/src/jvmMain/kotlin/pl/treksoft/kvision/remote/KVServiceManager.kt
+++ b/kvision-modules/kvision-server-jooby/src/jvmMain/kotlin/pl/treksoft/kvision/remote/KVServiceManager.kt
@@ -41,6 +41,7 @@ import org.slf4j.LoggerFactory
 import pl.treksoft.kvision.types.*
 import kotlin.reflect.KClass
 
+typealias RequestHandler = suspend HandlerContext.() -> Any
 
 /**
  * Multiplatform service manager for Jooby.
@@ -52,13 +53,24 @@ actual open class KVServiceManager<T : Any> actual constructor(val serviceClass:
         val LOG: Logger = LoggerFactory.getLogger(KVServiceManager::class.java.name)
     }
 
-    val getRequests: MutableMap<String, suspend HandlerContext.() -> Any> = mutableMapOf()
-    val postRequests: MutableMap<String, suspend HandlerContext.() -> Any> = mutableMapOf()
-    val putRequests: MutableMap<String, suspend HandlerContext.() -> Any> = mutableMapOf()
-    val deleteRequests: MutableMap<String, suspend HandlerContext.() -> Any> =
-        mutableMapOf()
-    val optionsRequests: MutableMap<String, suspend HandlerContext.() -> Any> =
-        mutableMapOf()
+    val routeMapRegistry = createRouteMapRegistry<RequestHandler>()
+
+    @Suppress("DEPRECATION")
+    @Deprecated("use routeMapRegistry instead", ReplaceWith("routeMapRegistry"))
+    val getRequests by RouteMapDelegate(routeMapRegistry, HttpMethod.GET)
+    @Suppress("DEPRECATION")
+    @Deprecated("use routeMapRegistry instead", ReplaceWith("routeMapRegistry"))
+    val postRequests by RouteMapDelegate(routeMapRegistry, HttpMethod.POST)
+    @Suppress("DEPRECATION")
+    @Deprecated("use routeMapRegistry instead", ReplaceWith("routeMapRegistry"))
+    val putRequests by RouteMapDelegate(routeMapRegistry, HttpMethod.PUT)
+    @Suppress("DEPRECATION")
+    @Deprecated("use routeMapRegistry instead", ReplaceWith("routeMapRegistry"))
+    val deleteRequests by RouteMapDelegate(routeMapRegistry, HttpMethod.DELETE)
+    @Suppress("DEPRECATION")
+    @Deprecated("use routeMapRegistry instead", ReplaceWith("routeMapRegistry"))
+    val optionsRequests by RouteMapDelegate(routeMapRegistry, HttpMethod.OPTIONS)
+
     val webSocketRequests: MutableMap<String, (ctx: Context, configurer: WebSocketConfigurer) -> Unit> =
         mutableMapOf()
 
@@ -502,15 +514,9 @@ actual open class KVServiceManager<T : Any> actual constructor(val serviceClass:
     fun addRoute(
         method: HttpMethod,
         path: String,
-        handler: suspend HandlerContext.() -> Any
+        handler: RequestHandler
     ) {
-        when (method) {
-            HttpMethod.GET -> getRequests[path] = handler
-            HttpMethod.POST -> postRequests[path] = handler
-            HttpMethod.PUT -> putRequests[path] = handler
-            HttpMethod.DELETE -> deleteRequests[path] = handler
-            HttpMethod.OPTIONS -> optionsRequests[path] = handler
-        }
+        routeMapRegistry.addRoute(method, path, handler)
     }
 
     /**
@@ -532,20 +538,14 @@ actual open class KVServiceManager<T : Any> actual constructor(val serviceClass:
  * A function to generate routes based on definitions from the service manager.
  */
 fun <T : Any> CoroutineRouter.applyRoutes(serviceManager: KVServiceManager<T>) {
-    serviceManager.getRequests.forEach { (path, handler) ->
-        get(path, handler)
-    }
-    serviceManager.postRequests.forEach { (path, handler) ->
-        post(path, handler)
-    }
-    serviceManager.putRequests.forEach { (path, handler) ->
-        put(path, handler)
-    }
-    serviceManager.deleteRequests.forEach { (path, handler) ->
-        delete(path, handler)
-    }
-    serviceManager.optionsRequests.forEach { (path, handler) ->
-        options(path, handler)
+    serviceManager.routeMapRegistry.asSequence().forEach { (method, path, handler) ->
+        when(method) {
+            HttpMethod.GET -> get(path, handler)
+            HttpMethod.POST -> post(path, handler)
+            HttpMethod.PUT -> put(path, handler)
+            HttpMethod.DELETE -> delete(path, handler)
+            HttpMethod.OPTIONS -> options(path, handler)
+        }
     }
     serviceManager.webSocketRequests.forEach { (path, handler) ->
         this.router.ws(path, handler)

--- a/kvision-modules/kvision-server-ktor/src/jvmMain/kotlin/pl/treksoft/kvision/remote/KVServiceManager.kt
+++ b/kvision-modules/kvision-server-ktor/src/jvmMain/kotlin/pl/treksoft/kvision/remote/KVServiceManager.kt
@@ -21,26 +21,13 @@
  */
 package pl.treksoft.kvision.remote
 
-import com.fasterxml.jackson.databind.module.SimpleModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
-import io.ktor.application.ApplicationCall
-import io.ktor.application.call
-import io.ktor.http.cio.websocket.CloseReason
-import io.ktor.http.cio.websocket.Frame
-import io.ktor.http.cio.websocket.close
-import io.ktor.http.cio.websocket.readText
-import io.ktor.request.receive
-import io.ktor.response.respond
-import io.ktor.routing.Route
-import io.ktor.routing.delete
-import io.ktor.routing.get
-import io.ktor.routing.options
-import io.ktor.routing.post
-import io.ktor.routing.put
-import io.ktor.util.pipeline.PipelineContext
-import io.ktor.websocket.WebSocketServerSession
-import io.ktor.websocket.webSocket
+import io.ktor.application.*
+import io.ktor.http.cio.websocket.*
+import io.ktor.request.*
+import io.ktor.response.*
+import io.ktor.routing.*
+import io.ktor.util.pipeline.*
+import io.ktor.websocket.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ClosedSendChannelException
@@ -51,12 +38,6 @@ import kotlinx.coroutines.launch
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import pl.treksoft.kvision.types.*
-import java.math.BigDecimal
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.LocalTime
-import java.time.OffsetDateTime
-import java.time.OffsetTime
 import kotlin.reflect.KClass
 
 /**
@@ -79,22 +60,7 @@ actual open class KVServiceManager<T : Any> actual constructor(val serviceClass:
     val webSocketRequests: MutableMap<String, suspend WebSocketServerSession.() -> Unit> =
         mutableMapOf()
 
-    val mapper = jacksonObjectMapper().apply {
-        val module = SimpleModule()
-        module.addSerializer(LocalDateTime::class.java, LocalDateTimeSerializer())
-        module.addSerializer(LocalDate::class.java, LocalDateSerializer())
-        module.addSerializer(LocalTime::class.java, LocalTimeSerializer())
-        module.addSerializer(OffsetDateTime::class.java, OffsetDateTimeSerializer())
-        module.addSerializer(OffsetTime::class.java, OffsetTimeSerializer())
-        module.addSerializer(BigDecimal::class.java, BigDecimalSerializer())
-        module.addDeserializer(LocalDateTime::class.java, LocalDateTimeDeserializer())
-        module.addDeserializer(LocalDate::class.java, LocalDateDeserializer())
-        module.addDeserializer(LocalTime::class.java, LocalTimeDeserializer())
-        module.addDeserializer(OffsetDateTime::class.java, OffsetDateTimeDeserializer())
-        module.addDeserializer(OffsetTime::class.java, OffsetTimeDeserializer())
-        module.addDeserializer(BigDecimal::class.java, BigDecimalDeserializer())
-        this.registerModule(module)
-    }
+    val mapper = createDefaultObjectMapper()
     var counter: Int = 0
 
     /**

--- a/kvision-modules/kvision-server-micronaut/build.gradle.kts
+++ b/kvision-modules/kvision-server-micronaut/build.gradle.kts
@@ -14,6 +14,8 @@ val coroutinesVersion: String by project
 val micronautVersion: String by project
 val jacksonModuleKotlinVersion: String by project
 val logbackVersion: String by project
+val testNgVersion: String by project
+val hamcrestVersion: String by project
 
 kotlin {
     kotlinJsTargets()
@@ -45,6 +47,12 @@ kotlin {
                 api("io.micronaut:micronaut-websocket")
                 api("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonModuleKotlinVersion")
                 api("ch.qos.logback:logback-classic:$logbackVersion")
+            }
+        }
+        val jvmTest by getting {
+            dependencies {
+                implementation("org.testng:testng:$testNgVersion")
+                implementation("org.hamcrest:hamcrest:$hamcrestVersion")
             }
         }
     }

--- a/kvision-modules/kvision-server-micronaut/src/jvmMain/kotlin/pl/treksoft/kvision/remote/KVServiceManager.kt
+++ b/kvision-modules/kvision-server-micronaut/src/jvmMain/kotlin/pl/treksoft/kvision/remote/KVServiceManager.kt
@@ -21,9 +21,6 @@
  */
 package pl.treksoft.kvision.remote
 
-import com.fasterxml.jackson.databind.module.SimpleModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import io.micronaut.context.ApplicationContext
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
@@ -36,13 +33,6 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import pl.treksoft.kvision.types.*
-import java.math.BigDecimal
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.LocalTime
-import java.time.OffsetDateTime
-import java.time.OffsetTime
 import kotlin.reflect.KClass
 
 /**
@@ -69,22 +59,7 @@ actual open class KVServiceManager<T : Any> actual constructor(val serviceClass:
         WebSocketSession, ThreadLocal<WebSocketSession>, ApplicationContext, ReceiveChannel<String>, SendChannel<String>
     ) -> Unit> = mutableMapOf()
 
-    val mapper = jacksonObjectMapper().apply {
-        val module = SimpleModule()
-        module.addSerializer(LocalDateTime::class.java, LocalDateTimeSerializer())
-        module.addSerializer(LocalDate::class.java, LocalDateSerializer())
-        module.addSerializer(LocalTime::class.java, LocalTimeSerializer())
-        module.addSerializer(OffsetDateTime::class.java, OffsetDateTimeSerializer())
-        module.addSerializer(OffsetTime::class.java, OffsetTimeSerializer())
-        module.addSerializer(BigDecimal::class.java, BigDecimalSerializer())
-        module.addDeserializer(LocalDateTime::class.java, LocalDateTimeDeserializer())
-        module.addDeserializer(LocalDate::class.java, LocalDateDeserializer())
-        module.addDeserializer(LocalTime::class.java, LocalTimeDeserializer())
-        module.addDeserializer(OffsetDateTime::class.java, OffsetDateTimeDeserializer())
-        module.addDeserializer(OffsetTime::class.java, OffsetTimeDeserializer())
-        module.addDeserializer(BigDecimal::class.java, BigDecimalDeserializer())
-        this.registerModule(module)
-    }
+    val mapper = createDefaultObjectMapper()
     var counter: Int = 0
 
     /**

--- a/kvision-modules/kvision-server-micronaut/src/jvmMain/kotlin/pl/treksoft/kvision/remote/Security.kt
+++ b/kvision-modules/kvision-server-micronaut/src/jvmMain/kotlin/pl/treksoft/kvision/remote/Security.kt
@@ -22,16 +22,11 @@
 
 package pl.treksoft.kvision.remote
 
-import io.micronaut.http.HttpMethod
 import io.micronaut.http.HttpRequest
 
 fun <T> HttpRequest<T>.matches(vararg services: KVServiceManager<*>): Boolean {
-    return when (this.method) {
-        HttpMethod.GET -> services.flatMap { it.getRequests.keys }.contains(this.uri.path)
-        HttpMethod.POST -> services.flatMap { it.postRequests.keys }.contains(this.uri.path)
-        HttpMethod.PUT -> services.flatMap { it.putRequests.keys }.contains(this.uri.path)
-        HttpMethod.DELETE -> services.flatMap { it.deleteRequests.keys }.contains(this.uri.path)
-        HttpMethod.OPTIONS -> services.flatMap { it.optionsRequests.keys }.contains(this.uri.path)
-        else -> false
-    }
+    val kVisionMethod = HttpMethod.fromStringOrNull(this.method.name) ?: return false
+    return services.asSequence().flatMap { service ->
+        service.routeMapRegistry.asSequence(kVisionMethod).map(RouteMapEntry<*>::path)
+    }.contains(this.uri.path)
 }

--- a/kvision-modules/kvision-server-micronaut/src/jvmTest/kotlin/pl/treksoft/kvision/remote/RouteMapRegistryKtTest.kt
+++ b/kvision-modules/kvision-server-micronaut/src/jvmTest/kotlin/pl/treksoft/kvision/remote/RouteMapRegistryKtTest.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2017-present Robert Jaros
+ * Copyright (c) 2020 Yannik Hampe
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package pl.treksoft.kvision.remote
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.*
+import org.testng.annotations.BeforeMethod
+import org.testng.annotations.DataProvider
+import org.testng.annotations.Test
+
+const val GET_PATH_A = "get path A"
+const val GET_PATH_B = "get path B"
+const val POST_PATH = "post path"
+const val GET_HANDLER_A = "get handler A"
+const val GET_HANDLER_B = "get handler B"
+const val POST_HANDLER = "post handler"
+
+class RouteMapRegistryKtTest {
+    private lateinit var registry: RouteMapRegistry<String>
+
+    @BeforeMethod
+    fun setUp() {
+        registry = createRouteMapRegistry()
+        registry.addRoute(HttpMethod.GET, GET_PATH_A, GET_HANDLER_A)
+        registry.addRoute(HttpMethod.GET, GET_PATH_B, GET_HANDLER_B)
+        registry.addRoute(HttpMethod.POST, POST_PATH, POST_HANDLER)
+    }
+
+    @Test(dataProvider = "provide_method_path_expected")
+    fun findHandler_findsExpectedHandler(method: HttpMethod, path: String, expected: String?) {
+        // execution
+        val actual = registry.findHandler(method, path)
+
+        // evaluation
+        assertThat(actual, equalTo(expected))
+    }
+
+    @DataProvider
+    fun provide_method_path_expected(): Array<Array<Any?>> {
+        fun args(method: HttpMethod, path: String, expected: String?): Array<Any?> = arrayOf(method, path, expected)
+
+        return arrayOf(
+            // Get existing path
+            args(HttpMethod.GET, GET_PATH_A, GET_HANDLER_A),
+            // Get path that does not exist at all (should return null)
+            args(HttpMethod.OPTIONS, "does not exist", null),
+            // Get path that exists with different method (should return null)
+            args(HttpMethod.GET, POST_PATH, null),
+        )
+    }
+
+    @Test
+    fun asSequence_returnsAllEntries() {
+        // execution
+        val actual = registry.asSequence().toList()
+
+        // evaluation
+        assertThat(actual, containsInAnyOrder(
+            RouteMapEntry(HttpMethod.GET, GET_PATH_A, GET_HANDLER_A),
+            RouteMapEntry(HttpMethod.GET, GET_PATH_B, GET_HANDLER_B),
+            RouteMapEntry(HttpMethod.POST, POST_PATH, POST_HANDLER),
+        ))
+    }
+
+    @Test(dataProvider = "provide_method_expected")
+    fun forEach_runsForEachHandlerWithRequestedMethod(method: HttpMethod, expected: Array<RouteMapEntry<String>>) {
+        // execution
+        val actual = registry.asSequence(method).toList()
+
+        // evaluation
+        assertThat(actual, containsInAnyOrder(*expected))
+    }
+
+    @DataProvider
+    fun provide_method_expected(): Array<Array<Any>> {
+        fun args(method: HttpMethod, expected: Array<RouteMapEntry<String>>): Array<Any> = arrayOf(method, expected)
+
+        return arrayOf(
+            args(
+                HttpMethod.GET,
+                arrayOf(
+                    RouteMapEntry(HttpMethod.GET, GET_PATH_A, GET_HANDLER_A),
+                    RouteMapEntry(HttpMethod.GET, GET_PATH_B, GET_HANDLER_B)
+                )
+            ),
+            args(HttpMethod.POST, arrayOf(RouteMapEntry(HttpMethod.POST, POST_PATH, POST_HANDLER))),
+            args(HttpMethod.DELETE, kotlin.emptyArray())
+        )
+    }
+}

--- a/kvision-modules/kvision-server-spring-boot/src/jvmMain/kotlin/pl/treksoft/kvision/remote/KVServiceManager.kt
+++ b/kvision-modules/kvision-server-spring-boot/src/jvmMain/kotlin/pl/treksoft/kvision/remote/KVServiceManager.kt
@@ -21,9 +21,6 @@
  */
 package pl.treksoft.kvision.remote
 
-import com.fasterxml.jackson.databind.module.SimpleModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ReceiveChannel
@@ -41,12 +38,6 @@ import org.springframework.web.reactive.function.server.bodyValueAndAwait
 import org.springframework.web.reactive.function.server.json
 import org.springframework.web.reactive.socket.WebSocketSession
 import pl.treksoft.kvision.types.*
-import java.math.BigDecimal
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.LocalTime
-import java.time.OffsetDateTime
-import java.time.OffsetTime
 import kotlin.reflect.KClass
 
 /**
@@ -73,23 +64,7 @@ actual open class KVServiceManager<T : Any> actual constructor(val serviceClass:
         WebSocketSession, ThreadLocal<WebSocketSession>, ApplicationContext, ReceiveChannel<String>, SendChannel<String>
     ) -> Unit> =
         mutableMapOf()
-
-    val mapper = jacksonObjectMapper().apply {
-        val module = SimpleModule()
-        module.addSerializer(LocalDateTime::class.java, LocalDateTimeSerializer())
-        module.addSerializer(LocalDate::class.java, LocalDateSerializer())
-        module.addSerializer(LocalTime::class.java, LocalTimeSerializer())
-        module.addSerializer(OffsetDateTime::class.java, OffsetDateTimeSerializer())
-        module.addSerializer(OffsetTime::class.java, OffsetTimeSerializer())
-        module.addSerializer(BigDecimal::class.java, BigDecimalSerializer())
-        module.addDeserializer(LocalDateTime::class.java, LocalDateTimeDeserializer())
-        module.addDeserializer(LocalDate::class.java, LocalDateDeserializer())
-        module.addDeserializer(LocalTime::class.java, LocalTimeDeserializer())
-        module.addDeserializer(OffsetDateTime::class.java, OffsetDateTimeDeserializer())
-        module.addDeserializer(OffsetTime::class.java, OffsetTimeDeserializer())
-        module.addDeserializer(BigDecimal::class.java, BigDecimalDeserializer())
-        this.registerModule(module)
-    }
+    val mapper = createDefaultObjectMapper()
     var counter: Int = 0
 
     /**

--- a/kvision-modules/kvision-server-vertx/src/jvmMain/kotlin/pl/treksoft/kvision/remote/KVServiceManager.kt
+++ b/kvision-modules/kvision-server-vertx/src/jvmMain/kotlin/pl/treksoft/kvision/remote/KVServiceManager.kt
@@ -21,9 +21,6 @@
  */
 package pl.treksoft.kvision.remote
 
-import com.fasterxml.jackson.databind.module.SimpleModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import com.google.inject.Injector
 import io.vertx.core.Vertx
 import io.vertx.core.http.ServerWebSocket
@@ -41,12 +38,6 @@ import kotlinx.coroutines.launch
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import pl.treksoft.kvision.types.*
-import java.math.BigDecimal
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.LocalTime
-import java.time.OffsetDateTime
-import java.time.OffsetTime
 import kotlin.reflect.KClass
 
 /**
@@ -71,22 +62,7 @@ actual open class KVServiceManager<T : Any> actual constructor(val serviceClass:
     val webSocketRequests: MutableMap<String, (Injector, ServerWebSocket) -> Unit> =
         mutableMapOf()
 
-    val mapper = jacksonObjectMapper().apply {
-        val module = SimpleModule()
-        module.addSerializer(LocalDateTime::class.java, LocalDateTimeSerializer())
-        module.addSerializer(LocalDate::class.java, LocalDateSerializer())
-        module.addSerializer(LocalTime::class.java, LocalTimeSerializer())
-        module.addSerializer(OffsetDateTime::class.java, OffsetDateTimeSerializer())
-        module.addSerializer(OffsetTime::class.java, OffsetTimeSerializer())
-        module.addSerializer(BigDecimal::class.java, BigDecimalSerializer())
-        module.addDeserializer(LocalDateTime::class.java, LocalDateTimeDeserializer())
-        module.addDeserializer(LocalDate::class.java, LocalDateDeserializer())
-        module.addDeserializer(LocalTime::class.java, LocalTimeDeserializer())
-        module.addDeserializer(OffsetDateTime::class.java, OffsetDateTimeDeserializer())
-        module.addDeserializer(OffsetTime::class.java, OffsetTimeDeserializer())
-        module.addDeserializer(BigDecimal::class.java, BigDecimalDeserializer())
-        this.registerModule(module)
-    }
+    val mapper = createDefaultObjectMapper()
     var counter: Int = 0
 
     /**


### PR DESCRIPTION
As a follow-up to #205: I had a look at the other implementations of `KVServiceManager` and they are all really similar. I believe it should not be a problem to move most of the code into a common package. I tried to do so, and after all the different `KVServiceManager` classes (1xexpected, 2xactual, for each backend) caused a stack overflow in my brain, I thought that maybe I should tackle this in smaller steps. Also maybe it is better to get some feedback whether this is actually going into the right direction...

So in this PR I take two small steps:
1. I extracted the object-mapper-creation into a common method, since it is exactly the same for all for all backends. I wasn't quite sure whether to put it in `kvision-common-types` or in `kvision-common-remote`. I decided for the later, but maybe that's wrong. However that's easy to change.
2. I extracted the `(get|post|put|delete|options)Requests`-properties, which are also exactly the same for all `KVServiceManager` in the backend into a a common class. Actually I also unified those properties into a single `Map`. It does seem like it is quite often useful to access the values by a dynamic key.

In the process I noticed that there backend has... Zero unit tests. In case I did not miss any. So far I only refactored and for that it was not that important, but now since I added new code I noticed. Since there was no testing framework in the dependencies I added TestNG&Hamcrest, because I personally like those the most. However if you prefer something else, it shouldn't be a problem to adjust... However that also means that the refactorings I did are... Basically untested, except for "it compiles"...

Side note: There is this `mapper.readValue(str)`-statement which IDEA says about:
> None of the following functions can be called with the arguments supplied.[ ... long list of options ... ]

IDEA wants a `import com.fasterxml.jackson.module.kotlin.readValue` then it is happy. But Gradle build everything quite happily without the import. I wonder what that is about...

Other side note: `var counter: Int = 0`... Should this be `private`? It doesn't seem very useful to be public-API... 