### PR TITLE
refactor KVServiceManager: move management of webSocketsRequests to super class

### DIFF
--- a/kvision-modules/kvision-server-javalin/src/jvmMain/kotlin/pl/treksoft/kvision/remote/KVServiceManager.kt
+++ b/kvision-modules/kvision-server-javalin/src/jvmMain/kotlin/pl/treksoft/kvision/remote/KVServiceManager.kt
@@ -41,21 +41,20 @@ import org.slf4j.LoggerFactory
 import kotlin.reflect.KClass
 
 typealias RequestHandler = (Context) -> Unit
+typealias WebsocketHandler = (WsHandler) -> Unit
 
 /**
  * Multiplatform service manager for Javalin.
  */
 @Suppress("LargeClass", "TooManyFunctions", "BlockingMethodInNonBlockingContext")
 actual open class KVServiceManager<T : Any> actual constructor(val serviceClass: KClass<T>) : KVServiceMgr<T>,
-    KVServiceBinder<T, RequestHandler>() {
+    KVServiceBinder<T, RequestHandler, WebsocketHandler>() {
 
     companion object {
         val LOG: Logger = LoggerFactory.getLogger(KVServiceManager::class.java.name)
         const val KV_WS_INCOMING_KEY = "pl.treksoft.kvision.ws.incoming.key"
         const val KV_WS_OUTGOING_KEY = "pl.treksoft.kvision.ws.outgoing.key"
     }
-
-    val webSocketRequests: MutableMap<String, (WsHandler) -> Unit> = mutableMapOf()
 
     /**
      * @suppress internal function
@@ -119,18 +118,12 @@ actual open class KVServiceManager<T : Any> actual constructor(val serviceClass:
             ctx.json(future)
         }
 
-    /**
-     * Binds a given web socket connection with a function of the receiver.
-     * @param function a function of the receiver
-     * @param route a route
-     */
-    @OptIn(ExperimentalCoroutinesApi::class)
-    protected actual inline fun <reified PAR1 : Any, reified PAR2 : Any> bind(
-        noinline function: suspend T.(ReceiveChannel<PAR1>, SendChannel<PAR2>) -> Unit,
-        route: String?
-    ) {
-        val routeDef = route ?: generateRouteName()
-        webSocketRequests["/kvws/$routeDef"] = { ws ->
+    override fun <REQ, RES> createWebsocketHandler(
+        requestMessageType: Class<REQ>,
+        responseMessageType: Class<RES>,
+        function: suspend T.(ReceiveChannel<REQ>, SendChannel<RES>) -> Unit
+    ): WebsocketHandler =
+        { ws ->
             ws.onConnect { ctx ->
                 val incoming = Channel<String>()
                 val outgoing = Channel<String>()
@@ -148,14 +141,16 @@ actual open class KVServiceManager<T : Any> actual constructor(val serviceClass:
                             ctx.session.close()
                         }
                         launch {
-                            val requestChannel = Channel<PAR1>()
-                            val responseChannel = Channel<PAR2>()
+                            val requestChannel = Channel<REQ>()
+                            val responseChannel = Channel<RES>()
                             coroutineScope {
                                 launch {
                                     for (p in incoming) {
                                         val jsonRpcRequest = deSerializer.deserialize<JsonRpcRequest>(p)
                                         if (jsonRpcRequest.params.size == 1) {
-                                            val par = deSerializer.deserialize<PAR1>(jsonRpcRequest.params[0])
+                                            val par = deSerializer.deserialize(
+                                                jsonRpcRequest.params[0], requestMessageType
+                                            )
                                             requestChannel.send(par)
                                         }
                                     }
@@ -197,7 +192,6 @@ actual open class KVServiceManager<T : Any> actual constructor(val serviceClass:
                 }
             }
         }
-    }
 }
 
 /**

--- a/kvision-modules/kvision-server-spring-boot/src/jvmMain/kotlin/pl/treksoft/kvision/remote/KVServiceManager.kt
+++ b/kvision-modules/kvision-server-spring-boot/src/jvmMain/kotlin/pl/treksoft/kvision/remote/KVServiceManager.kt
@@ -40,21 +40,19 @@ import org.springframework.web.reactive.socket.WebSocketSession
 import kotlin.reflect.KClass
 
 typealias RequestHandler = suspend (ServerRequest, ThreadLocal<ServerRequest>, ApplicationContext) -> ServerResponse
+typealias WebsocketHandler = suspend (
+    WebSocketSession, ThreadLocal<WebSocketSession>, ApplicationContext, ReceiveChannel<String>, SendChannel<String>
+) -> Unit
 /**
  * Multiplatform service manager for Spring Boot.
  */
 @Suppress("LargeClass", "TooManyFunctions", "BlockingMethodInNonBlockingContext")
 actual open class KVServiceManager<T : Any> actual constructor(val serviceClass: KClass<T>) : KVServiceMgr<T>,
-    KVServiceBinder<T, RequestHandler>() {
+    KVServiceBinder<T, RequestHandler, WebsocketHandler>() {
 
     companion object {
         val LOG: Logger = LoggerFactory.getLogger(KVServiceManager::class.java.name)
     }
-
-    val webSocketsRequests: MutableMap<String, suspend (
-        WebSocketSession, ThreadLocal<WebSocketSession>, ApplicationContext, ReceiveChannel<String>, SendChannel<String>
-    ) -> Unit> = mutableMapOf()
-
     /**
      * @suppress internal function
      */
@@ -109,18 +107,13 @@ actual open class KVServiceManager<T : Any> actual constructor(val serviceClass:
             }))
         }
 
-    /**
-     * Binds a given web socket connetion with a function of the receiver.
-     * @param function a function of the receiver
-     * @param route a route
-     */
     @OptIn(ExperimentalCoroutinesApi::class)
-    protected actual inline fun <reified PAR1 : Any, reified PAR2 : Any> bind(
-        noinline function: suspend T.(ReceiveChannel<PAR1>, SendChannel<PAR2>) -> Unit,
-        route: String?
-    ) {
-        val routeDef = route ?: generateRouteName()
-        webSocketsRequests[routeDef] = { webSocketSession, tlWsSession, ctx, incoming, outgoing ->
+    override fun <REQ, RES> createWebsocketHandler(
+        requestMessageType: Class<REQ>,
+        responseMessageType: Class<RES>,
+        function: suspend T.(ReceiveChannel<REQ>, SendChannel<RES>) -> Unit
+    ): WebsocketHandler =
+        { webSocketSession, tlWsSession, ctx, incoming, outgoing ->
             tlWsSession.set(webSocketSession)
             val service = ctx.getBean(serviceClass.java)
             tlWsSession.remove()
@@ -133,14 +126,14 @@ actual open class KVServiceManager<T : Any> actual constructor(val serviceClass:
                 val principal = webSocketSession.handshakeInfo.principal.awaitSingle()
                 service.principal = principal
             }
-            val requestChannel = Channel<PAR1>()
-            val responseChannel = Channel<PAR2>()
+            val requestChannel = Channel<REQ>()
+            val responseChannel = Channel<RES>()
             coroutineScope {
                 launch {
                     for (p in incoming) {
                         val jsonRpcRequest = deSerializer.deserialize<JsonRpcRequest>(p)
                         if (jsonRpcRequest.params.size == 1) {
-                            val par = deSerializer.deserialize<PAR1>(jsonRpcRequest.params[0])
+                            val par = deSerializer.deserialize(jsonRpcRequest.params[0], requestMessageType)
                             requestChannel.send(par)
                         }
                     }
@@ -164,5 +157,4 @@ actual open class KVServiceManager<T : Any> actual constructor(val serviceClass:
                 }
             }
         }
-    }
 }

--- a/kvision-modules/kvision-server-vertx/src/jvmMain/kotlin/pl/treksoft/kvision/remote/KVServiceManager.kt
+++ b/kvision-modules/kvision-server-vertx/src/jvmMain/kotlin/pl/treksoft/kvision/remote/KVServiceManager.kt
@@ -40,19 +40,18 @@ import org.slf4j.LoggerFactory
 import kotlin.reflect.KClass
 
 typealias RequestHandler = (RoutingContext) -> Unit
+typealias WebsocketHandler = (Injector, ServerWebSocket) -> Unit
 
 /**
  * Multiplatform service manager for Vert.x.
  */
 @Suppress("LargeClass", "TooManyFunctions", "BlockingMethodInNonBlockingContext")
 actual open class KVServiceManager<T : Any> actual constructor(val serviceClass: KClass<T>) : KVServiceMgr<T>,
-    KVServiceBinder<T, RequestHandler>() {
+    KVServiceBinder<T, RequestHandler, WebsocketHandler>() {
 
     companion object {
         val LOG: Logger = LoggerFactory.getLogger(KVServiceManager::class.java.name)
     }
-
-    val webSocketRequests: MutableMap<String, (Injector, ServerWebSocket) -> Unit> = mutableMapOf()
 
     @Suppress("TooGenericExceptionCaught")
     override fun createRequestHandler(
@@ -89,18 +88,13 @@ actual open class KVServiceManager<T : Any> actual constructor(val serviceClass:
             }
         }
 
-    /**
-     * Binds a given web socket connection with a function of the receiver.
-     * @param function a function of the receiver
-     * @param route a route
-     */
     @OptIn(ExperimentalCoroutinesApi::class)
-    protected actual inline fun <reified PAR1 : Any, reified PAR2 : Any> bind(
-        noinline function: suspend T.(ReceiveChannel<PAR1>, SendChannel<PAR2>) -> Unit,
-        route: String?
-    ) {
-        val routeDef = route ?: generateRouteName()
-        webSocketRequests["/kvws/$routeDef"] = { injector, ws ->
+    override fun <REQ, RES> createWebsocketHandler(
+        requestMessageType: Class<REQ>,
+        responseMessageType: Class<RES>,
+        function: suspend T.(ReceiveChannel<REQ>, SendChannel<RES>) -> Unit
+    ): WebsocketHandler =
+        { injector, ws ->
             val incoming = Channel<String>()
             val outgoing = Channel<String>()
             val service = injector.getInstance(serviceClass.java)
@@ -131,14 +125,14 @@ actual open class KVServiceManager<T : Any> actual constructor(val serviceClass:
                         if (!ws.isClosed) ws.close()
                     }
                     launch {
-                        val requestChannel = Channel<PAR1>()
-                        val responseChannel = Channel<PAR2>()
+                        val requestChannel = Channel<REQ>()
+                        val responseChannel = Channel<RES>()
                         coroutineScope {
                             launch {
                                 for (p in incoming) {
                                     val jsonRpcRequest = deSerializer.deserialize<JsonRpcRequest>(p)
                                     if (jsonRpcRequest.params.size == 1) {
-                                        val par = deSerializer.deserialize<PAR1>(jsonRpcRequest.params[0])
+                                        val par = deSerializer.deserialize(jsonRpcRequest.params[0], requestMessageType)
                                         requestChannel.send(par)
                                     }
                                 }
@@ -165,7 +159,6 @@ actual open class KVServiceManager<T : Any> actual constructor(val serviceClass:
                 }
             }
         }
-    }
 }
 
 /**


### PR DESCRIPTION
This PR is only a smaller change: Management of "normal" HTTP-Requests is in the super class and management of websockets is still in the KVServiceManager. In this case it does not make that much of a difference, however I think it makes sense to have everything in one place. Additionally the bind-method for websockets has tests now...

This PR there includes an intentional error in the unit tests. I just want to make sure that the CI catches it. I will update the branch as soon as the CI completes.