### PR TITLE
refactor KVServiceManager: move most of the websocket handling code to common function

### DIFF
--- a/kvision-modules/kvision-common-remote/src/jvmMain/kotlin/pl/treksoft/kvision/remote/WebsocketHandler.kt
+++ b/kvision-modules/kvision-common-remote/src/jvmMain/kotlin/pl/treksoft/kvision/remote/WebsocketHandler.kt
@@ -1,0 +1,96 @@
+package pl.treksoft.kvision.remote
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
+
+/**
+ * Convenience function for cases were the raw channels work with strings. See the overloaded method for details.
+ */
+suspend fun <T, OBJECTS_IN, OBJECTS_OUT> handleWebsocketConnection(
+    deSerializer: ObjectDeSerializer,
+    rawIn: ReceiveChannel<String>,
+    rawOut: SendChannel<String>,
+    parsedInType: Class<OBJECTS_IN>,
+    service: T,
+    function: suspend T.(ReceiveChannel<OBJECTS_IN>, SendChannel<OBJECTS_OUT>) -> Unit
+) {
+    handleWebsocketConnection(
+        deSerializer = deSerializer,
+        rawIn = rawIn,
+        rawInToText = { it },
+        rawOut = rawOut,
+        rawOutFromText = { it },
+        parsedInType = parsedInType,
+        service = service,
+        function = function
+    )
+}
+
+/**
+ * Reads JSON-RPC calls from [rawIn], deserializes them and forwards them in form of a channel to [function].
+ * Additionally [function] also receives a [SendChannel], from which objects are read, serialized and sent to the client
+ * in the form of JSON-RPC calls.
+ *
+ * @param deSerializer used to (de-)serialize objects
+ * @param rawIn a channel that supplies serialized JSON-RPC calls
+ * @param rawInToText a function to convert the objects supplied by [rawIn] to a String. The function may return null to
+ *                    indicate that the message should be ignored
+ * @param rawOut a channel for outgoing messages
+ * @param rawOutFromText a function to convert the JSON-string to an object to be sent via [rawOut]
+ * @param parsedInType the type of object that [function] receives through a channel
+ * @param service the receiver to be used when calling [function]
+ * @param function the function to delegate data processing to
+ */
+@OptIn(FlowPreview::class)
+suspend fun <T, RAW_IN, RAW_OUT, OBJECTS_IN, OBJECTS_OUT> handleWebsocketConnection(
+    deSerializer: ObjectDeSerializer,
+    rawIn: ReceiveChannel<RAW_IN>,
+    rawInToText: (RAW_IN) -> String?,
+    rawOut: SendChannel<RAW_OUT>,
+    rawOutFromText: (String) -> RAW_OUT,
+    parsedInType: Class<OBJECTS_IN>,
+    service: T,
+    function: suspend T.(ReceiveChannel<OBJECTS_IN>, SendChannel<OBJECTS_OUT>) -> Unit
+) {
+    fun serializeMessage(message: Any?) = deSerializer.serializeNonNullToString(
+        JsonRpcResponse(
+            id = 0,
+            result = deSerializer.serializeNullableToString(message)
+        )
+    )
+    coroutineScope {
+        val parsedIn = rawIn
+            .consumeAsFlow()
+            .mapNotNull { rawInToText(it) }
+            .mapNotNull { deSerializer.deserialize<JsonRpcRequest>(it).params.singleOrNull() }
+            .map { deSerializer.deserialize(it, parsedInType) }
+            .produceIn(this)
+
+        val parsedOut = Channel<OBJECTS_OUT>()
+        parsedOut
+            .consumeAsFlow()
+            .map { rawOutFromText(serializeMessage(it)) }
+            .pipe(this, rawOut)
+
+        launch {
+            try {
+                function(service, parsedIn, parsedOut)
+            } finally {
+                parsedOut.close() // this also closes rawOut
+                rawIn.cancel()
+            }
+        }
+    }
+}
+
+private suspend fun <T> Flow<T>.pipe(scope: CoroutineScope, channel: SendChannel<T>) {
+    scope.launch {
+        onCompletion { channel.close(it) }.collect { channel.send(it) }
+    }
+}

--- a/kvision-modules/kvision-common-remote/src/jvmTest/kotlin/pl/treksoft/kvision/remote/WebsocketHandlerKtTest.kt
+++ b/kvision-modules/kvision-common-remote/src/jvmTest/kotlin/pl/treksoft/kvision/remote/WebsocketHandlerKtTest.kt
@@ -1,0 +1,163 @@
+package pl.treksoft.kvision.remote
+
+import com.fasterxml.jackson.core.JsonParseException
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.sync.Mutex
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.*
+import org.testng.Assert
+import org.testng.annotations.BeforeMethod
+import org.testng.annotations.Test
+
+@ExperimentalCoroutinesApi
+class WebsocketHandlerKtTest {
+    private val deSerializer = jacksonObjectDeSerializer()
+    private lateinit var service: DummyService
+    private lateinit var rawClientToServer: Channel<String>
+    private lateinit var rawServerToClient: Channel<String>
+    private val undeliveredFromClient = mutableListOf<String>()
+    private val undeliveredFromServer = mutableListOf<String>()
+
+    @BeforeMethod
+    fun setUp() {
+        service = DummyService()
+        rawClientToServer = Channel { undeliveredFromClient += it }
+        rawServerToClient = Channel { undeliveredFromServer += it }
+    }
+
+    @Test
+    fun passesParametersToFunction() {
+        // setup
+        val message = "a message from client to server"
+
+        // execution
+        val actual = runTest {
+            sendMessage(message)
+            service.incoming.receive()
+        }
+
+        // evaluation
+        assertChannelsClosedNoUndelivered()
+        assertThat(actual, equalTo(message))
+    }
+
+    @Test
+    fun writesDataGeneratedByFunctionToOutChannel() {
+        // setup
+        val message = "a message from server to client"
+
+        // execution
+        val actual = runTest {
+            service.outgoing.send(message)
+            rawServerToClient.receive()
+        }
+
+        // evaluation
+        assertThat(
+            deSerializer.deserialize<JsonRpcResponse>(actual).result,
+            // note that `result` is encoded as JSON within the JSON, thus double quotes:
+            equalTo("\"$message\"")
+        )
+    }
+
+    @Test
+    fun closesChannels_ifFunctionThrows() {
+        // execution (and throws evaluation)
+        Assert.assertThrows(DummyException::class.java) {
+            runTest {
+                service.beforeReturn = { throw DummyException() }
+            }
+        }
+
+        // evaluation
+        assertChannelsClosedNoUndelivered()
+    }
+
+    @Test
+    fun closesOnInvalidDataFromClient() {
+        // execution (and expect evaluation)
+        Assert.expectThrows(JsonParseException::class.java) {
+            runTest {
+                rawClientToServer.send("invalid")
+            }
+        }
+
+        // evaluation
+        assertChannelsClosedNoUndelivered()
+    }
+
+    private fun assertChannelsClosedNoUndelivered() {
+        assertThat("rawIncoming.isClosedForReceive", rawClientToServer.isClosedForReceive, equalTo(true))
+        assertThat("rawIncoming.isClosedForSend", rawClientToServer.isClosedForSend, equalTo(true))
+        assertThat("rawOutgoing.isClosedForReceive", rawServerToClient.isClosedForReceive, equalTo(true))
+        assertThat("rawOutgoing.isClosedForSend", rawServerToClient.isClosedForSend, equalTo(true))
+        assertThat(undeliveredFromClient, empty())
+        assertThat(undeliveredFromServer, empty())
+    }
+
+    private fun <T> runTest(test: suspend () -> T): T =
+        runBlocking {
+            handleWebsocketConnection(this)
+            withContext(Dispatchers.Default) {
+                service.waitUntilInitialized()
+                val result = test()
+                service.endSession()
+                result
+            }
+        }
+
+    private fun handleWebsocketConnection(scope: CoroutineScope) {
+        scope.launch {
+            handleWebsocketConnection<DummyService, String, String>(
+                deSerializer,
+                rawClientToServer,
+                rawServerToClient,
+                String::class.java,
+                service,
+                { receiveChannel, sendChannel -> service.serviceMethod(receiveChannel, sendChannel) }
+            )
+        }
+    }
+
+    private suspend fun sendMessage(message: String) {
+        rawClientToServer.send(deSerializer.serializeNonNullToString(JsonRpcRequest(
+            id = 42,
+            method = "dummy",
+            params = listOf(message)
+        )))
+    }
+}
+
+private class DummyException : Exception("dummy exception")
+
+private class DummyService {
+    var beforeReturn = {}
+    lateinit var incoming: ReceiveChannel<String>
+    lateinit var outgoing: SendChannel<String>
+
+    private val initialized = Mutex(true)
+    private val mayComplete = Mutex(true)
+
+    suspend fun serviceMethod(incoming: ReceiveChannel<String>, outgoing: SendChannel<String>) {
+        require(!this::incoming.isInitialized && !this::outgoing.isInitialized)
+        this.incoming = incoming
+        this.outgoing = outgoing
+        initialized.unlock()
+        // the actual logic happens in the test methods, so we just wait here until the test method signals that we
+        // may complete
+        mayComplete.lock()
+        beforeReturn()
+    }
+
+    suspend fun waitUntilInitialized() {
+        initialized.lock()
+        initialized.unlock()
+    }
+
+    fun endSession() {
+        mayComplete.unlock()
+    }
+}

--- a/kvision-modules/kvision-server-javalin/src/jvmMain/kotlin/pl/treksoft/kvision/remote/KVServiceManager.kt
+++ b/kvision-modules/kvision-server-javalin/src/jvmMain/kotlin/pl/treksoft/kvision/remote/KVServiceManager.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.future.future
 import kotlinx.coroutines.launch
@@ -134,45 +135,19 @@ actual open class KVServiceManager<T : Any> actual constructor(val serviceClass:
                 initializeWsService(service, ctx)
                 GlobalScope.launch {
                     coroutineScope {
-                        launch(Dispatchers.IO) {
-                            for (text in outgoing) {
-                                ctx.send(text)
-                            }
+                        launch {
+                            outgoing.consumeEach { ctx.send(it) }
                             ctx.session.close()
                         }
                         launch {
-                            val requestChannel = Channel<REQ>()
-                            val responseChannel = Channel<RES>()
-                            coroutineScope {
-                                launch {
-                                    for (p in incoming) {
-                                        val jsonRpcRequest = deSerializer.deserialize<JsonRpcRequest>(p)
-                                        if (jsonRpcRequest.params.size == 1) {
-                                            val par = deSerializer.deserialize(
-                                                jsonRpcRequest.params[0], requestMessageType
-                                            )
-                                            requestChannel.send(par)
-                                        }
-                                    }
-                                    requestChannel.close()
-                                }
-                                launch(Dispatchers.IO) {
-                                    for (p in responseChannel) {
-                                        val text = deSerializer.serializeNonNullToString(
-                                            JsonRpcResponse(
-                                                id = 0,
-                                                result = deSerializer.serializeNullableToString(p)
-                                            )
-                                        )
-                                        outgoing.send(text)
-                                    }
-                                }
-                                launch {
-                                    function.invoke(service, requestChannel, responseChannel)
-                                    if (!responseChannel.isClosedForReceive) responseChannel.close()
-                                }
-                            }
-                            if (!outgoing.isClosedForReceive) outgoing.close()
+                            handleWebsocketConnection(
+                                deSerializer = deSerializer,
+                                rawIn = incoming,
+                                rawOut = outgoing,
+                                parsedInType = requestMessageType,
+                                service = service,
+                                function = function
+                            )
                         }
                     }
                 }

--- a/kvision-modules/kvision-server-spring-boot/src/jvmMain/kotlin/pl/treksoft/kvision/remote/KVServiceManager.kt
+++ b/kvision-modules/kvision-server-spring-boot/src/jvmMain/kotlin/pl/treksoft/kvision/remote/KVServiceManager.kt
@@ -126,35 +126,14 @@ actual open class KVServiceManager<T : Any> actual constructor(val serviceClass:
                 val principal = webSocketSession.handshakeInfo.principal.awaitSingle()
                 service.principal = principal
             }
-            val requestChannel = Channel<REQ>()
-            val responseChannel = Channel<RES>()
-            coroutineScope {
-                launch {
-                    for (p in incoming) {
-                        val jsonRpcRequest = deSerializer.deserialize<JsonRpcRequest>(p)
-                        if (jsonRpcRequest.params.size == 1) {
-                            val par = deSerializer.deserialize(jsonRpcRequest.params[0], requestMessageType)
-                            requestChannel.send(par)
-                        }
-                    }
-                    requestChannel.close()
-                }
-                launch {
-                    for (p in responseChannel) {
-                        val text = deSerializer.serializeNonNullToString(
-                            JsonRpcResponse(
-                                id = 0,
-                                result = deSerializer.serializeNullableToString(p)
-                            )
-                        )
-                        outgoing.send(text)
-                    }
-                    if (!incoming.isClosedForReceive) incoming.cancel()
-                }
-                launch {
-                    function.invoke(service, requestChannel, responseChannel)
-                    if (!responseChannel.isClosedForReceive) responseChannel.close()
-                }
-            }
+
+            handleWebsocketConnection(
+                deSerializer = deSerializer,
+                rawIn = incoming,
+                rawOut = outgoing,
+                parsedInType = requestMessageType,
+                service = service,
+                function = function
+            )
         }
 }


### PR DESCRIPTION
I noticed that most of the code in the KVServiceManagers that handles websockets is the same. So I extracted most of it into a common function.

Some notes:

- Javalin used to use `Dispatchers.IO` when sending values (line 167). However this call was not doing any IO. Actually that channel looks pointless to me, because the data is just read in line 138, to be then forwarded to Javalin. The send call in line 137 also was using `Dispatchers.IO`. However Javalin's send-method delegates to `org.eclipse.jetty.websocket.api.RemoteEndpoint#sendStringByFuture` for which the documentation says:
    > Initiates the asynchronous transmission of a text message. This method may return before the message is transmitted. Developers may use the returned Future object to track progress of the transmission.
    
    So this is not doing any IO directly either, and thus I believe it is correct NOT to use `Dispatchers.IO`. I removed this.
- This is similar for Jooby, however there the documentation is not clear about this. I tracked the code a little bit and I see that it does delegate certain things to an executor which might run in a different thread, so I suspect, that this not doing any IO directly either. However I am not quite sure about that. So I left it in place for now.
- For KTor I removed this snippet:
    ```kotlin
    try {
        session.close(CloseReason(CloseReason.Codes.NORMAL, ""))
    } catch (e: ClosedSendChannelException) {
    }
    session.close()
    ```
    The `session.close` method that is called, looks like this:
    ```kotlin
    /**
     * Send a close frame with the specified [reason]. May suspend if outgoing channel is full.
     * The specified [reason] could be ignored if there was already
     * close frame sent (for example in reply to a peer close frame). It also may do nothing when a session or an outgoing
     * channel is already closed due to any reason.
     */
    public suspend fun WebSocketSession.close(reason: CloseReason = CloseReason(CloseReason.Codes.NORMAL, "")) {
        try {
            send(Frame.Close(reason))
            flush()
        } catch (_: Throwable) {
        }
    }
    ```
    So both calls of `close` are the same because the second call (without args) gets the default argument, which is the same as in the first call. Also this method has this `catch (_: Throwable)`, so it should be unable to throw a `ClosedSendChannelException`, so there is no point in catching that. Since the outgoing channel is closed at another point, I believe this close call can be omitted completely.
- There are some `if (!channel.isClosedForXXX) channel.close()` calls. The documentation says:
    > This is an idempotent operation - subsequent invocations of this function have no effect
    
    So the `if` check is unncessary. I removed those and just close the channel.
- What should happen, if the handler-method throws an exception? I think the channels should also be closed in that case and so far I don't see that this happens. I put the close call into a finally-block.

The good part is that I wrote some unit tests for testing, however I did not make a real live test. Do you have some demo application at hand for testing various things?