### PR TITLE
fix plugin setup when kvision is used in gradle subproject

### DIFF
--- a/kvision-tools/io.kvision.gradle.plugin/src/main/kotlin/io/kvision/gradle/KVisionGradleSubplugin.kt
+++ b/kvision-tools/io.kvision.gradle.plugin/src/main/kotlin/io/kvision/gradle/KVisionGradleSubplugin.kt
@@ -83,7 +83,7 @@ class KVisionGradleSubplugin : KotlinCompilerPluginSupportPlugin {
                         outputs.file(archiveFile)
                     }
                 }
-                extensions.configure<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension> {
+                rootProject.extensions.configure<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension> {
                     versions.webpackDevServer.version = "4.0.0"
                 }
             }
@@ -111,7 +111,7 @@ class KVisionGradleSubplugin : KotlinCompilerPluginSupportPlugin {
                         dependsOn("compileKotlinMetadata")
                     }
                 }
-                extensions.configure<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension> {
+                rootProject.extensions.configure<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension> {
                     versions.webpackDevServer.version = "4.0.0"
                 }
             }


### PR DESCRIPTION
Current version fails to init when kvision is used as a subproject. This pull request fixes this.
I have setup which contains kvision multiplatform project, and android project in one root project.
When applying kvision plugin gradle fails to sync with message:

```
* Exception is:
org.gradle.api.ProjectConfigurationException: A problem occurred configuring project ':template'.
...
Caused by: org.gradle.api.UnknownDomainObjectException: Extension of type 'NodeJsRootExtension' does not exist. Currently registered extension types: [ExtraPropertiesExtension, KotlinMultiplatformExtension, KotlinTestsRegistry, BasePluginExtension, DefaultArtifactPublicationSet, SourceSetContainer, ReportingExtension, JavaPluginExtension, JavaToolchainService, NamedDomainObjectContainer<BaseVariantOutput>, LibraryExtension, LibraryAndroidComponentsExtension, LibraryAndroidComponentsExtension]
	at org.gradle.internal.extensibility.ExtensionsStorage.getHolderByType(ExtensionsStorage.java:88)
	at org.gradle.internal.extensibility.ExtensionsStorage.configureExtension(ExtensionsStorage.java:70)
	at org.gradle.internal.extensibility.DefaultConvention.configure(DefaultConvention.java:189)
	at io.kvision.gradle.KVisionGradleSubplugin$apply$$inlined$with$lambda$2$1.execute(KVisionGradleSubplugin.kt:169)
	at io.kvision.gradle.KVisionGradleSubplugin$apply$$inlined$with$lambda$2$1.execute(KVisionGradleSubplugin.kt:42)
...
```