### PR TITLE
Use Dispatchers.Default for creating scope.

### DIFF
--- a/kvision-modules/kvision-state-flow/src/main/kotlin/io/kvision/core/Widget.kt
+++ b/kvision-modules/kvision-state-flow/src/main/kotlin/io/kvision/core/Widget.kt
@@ -22,16 +22,11 @@
 package io.kvision.core
 
 import io.kvision.utils.event
-import kotlinx.browser.window
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.asCoroutineDispatcher
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.plus
+import kotlinx.coroutines.*
 import org.w3c.dom.events.Event
 import org.w3c.dom.events.MouseEvent
 
-val KVScope = CoroutineScope(window.asCoroutineDispatcher()) + SupervisorJob()
+val KVScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
 
 /**
  * An extension function for defining on click suspending event handlers.


### PR DESCRIPTION
Small improvement of KVScope declaration. 
It uses `Dispatchers.Default` instead of `window.asCoroutineDispatcher`. Actually it leads to the same result (createDefaultDispatcher detects browser environment and use  `window.asCoroutineDispatcher`), but it's more clear you want Default dispatcher.

Also I moved SupervisorJob() as a CoroutineScope() parameter to avoid creating useless scope and job.
Result of `CoroutineScope(A) + B` is equal to `CoroutineScope(A + B)` 
In the first case it creates scope with context A(and default Job) and then get the context from it add B and create a new scope with context A+B