### PR TITLE
KVisionPlugin - remove afterEvaluate for lazily configured tasks

### DIFF
--- a/kvision-tools/kvision-gradle-plugin/src/main/kotlin/io/kvision/gradle/KVisionPlugin.kt
+++ b/kvision-tools/kvision-gradle-plugin/src/main/kotlin/io/kvision/gradle/KVisionPlugin.kt
@@ -226,15 +226,13 @@ abstract class KVisionPlugin @Inject constructor(
                 kotlinMppExtension.sourceSets.getByName("commonMain").kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
                 kotlinMppExtension.sourceSets.getByName("frontendMain").kotlin.srcDir("build/generated/ksp/frontend/frontendMain/kotlin")
                 kotlinMppExtension.sourceSets.getByName("backendMain").kotlin.srcDir("build/generated/ksp/backend/backendMain/kotlin")
+            }
 
-                afterEvaluate {
-                    tasks.all.kspKotlinFrontend.configureEach {
-                        dependsOn("kspCommonMainKotlinMetadata")
-                    }
-                    tasks.all.kspKotlinBackend.configureEach {
-                        dependsOn("kspCommonMainKotlinMetadata")
-                    }
-                }
+            tasks.all.kspKotlinFrontend.configureEach {
+                dependsOn("kspCommonMainKotlinMetadata")
+            }
+            tasks.all.kspKotlinBackend.configureEach {
+                dependsOn("kspCommonMainKotlinMetadata")
             }
         }
     }


### PR DESCRIPTION
a very minor tweak! I spotted these tasks were nested inside two `afterEvaluate {}` blocks. Because `configureEach {}` will configure the task only when the task is required, the configuration can be applied at any stage. 

If the task isn't created yet, then the configuration is applied later.