### PR TITLE
Generated resource directory - add KVision extension property

### DIFF
--- a/kvision-tools/kvision-gradle-plugin/src/main/kotlin/io/kvision/gradle/KVisionExtension.kt
+++ b/kvision-tools/kvision-gradle-plugin/src/main/kotlin/io/kvision/gradle/KVisionExtension.kt
@@ -42,6 +42,9 @@ abstract class KVisionExtension @Inject constructor(
     val irCompiler: Property<Boolean> = objects.property<Boolean>()
         .convention(providers.gradleProperty("kotlin.js.compiler").orElse("legacy").map { it == "ir" })
 
+    /** The location of generated resources that will be included in the packaged frontend. */
+    abstract val generatedFrontendResources: DirectoryProperty
+
     private fun kvisionGradleProperty(
         property: String,
         default: Boolean = true,

--- a/kvision-tools/kvision-gradle-plugin/src/main/kotlin/io/kvision/gradle/KVisionPlugin.kt
+++ b/kvision-tools/kvision-gradle-plugin/src/main/kotlin/io/kvision/gradle/KVisionPlugin.kt
@@ -3,6 +3,7 @@ package io.kvision.gradle
 import io.kvision.gradle.tasks.KVConvertPoTask
 import io.kvision.gradle.tasks.KVGeneratePotTask
 import io.kvision.gradle.tasks.KVWorkerBundleTask
+import javax.inject.Inject
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.NamedDomainObjectProvider
 import org.gradle.api.Plugin
@@ -33,7 +34,6 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
 import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpack
 import org.jetbrains.kotlin.gradle.targets.js.yarn.YarnRootExtension
-import javax.inject.Inject
 
 abstract class KVisionPlugin @Inject constructor(
     private val providers: ProviderFactory
@@ -80,6 +80,8 @@ abstract class KVisionPlugin @Inject constructor(
             nodeBinaryPath.convention(nodeJsBinaryProvider())
 
             kotlinJsStoreDirectory.convention(project.layout.projectDirectory.dir(".kotlin-js-store"))
+
+            generatedFrontendResources.convention(project.layout.buildDirectory.dir("generated/kvision/frontendResources"))
         }
     }
 
@@ -119,7 +121,7 @@ abstract class KVisionPlugin @Inject constructor(
                 layout.projectDirectory.dir("src/main/resources/i18n")
             )
             destinationDirectory.set(
-                layout.buildDirectory.dir("generated/resources/i18n")
+                kvExtension.generatedFrontendResources.dir("i18n")
             )
         }
 
@@ -141,7 +143,9 @@ abstract class KVisionPlugin @Inject constructor(
             }
         }
 
-        kotlinJsExtension.sourceSets.main.get().resources.srcDir(layout.buildDirectory.dir("generated/resources"))
+        kotlinJsExtension.sourceSets.main.configure {
+            resources.srcDir(kvExtension.generatedFrontendResources)
+        }
     }
 
 
@@ -171,7 +175,7 @@ abstract class KVisionPlugin @Inject constructor(
                 layout.projectDirectory.dir("src/frontendMain/resources/i18n")
             )
             destinationDirectory.set(
-                layout.buildDirectory.dir("generated/resources/i18n")
+                kvExtension.generatedFrontendResources.dir("i18n")
             )
         }
 
@@ -209,8 +213,8 @@ abstract class KVisionPlugin @Inject constructor(
             }
         }
 
-        afterEvaluate {
-            kotlinMppExtension.sourceSets.frontendMain.get().resources.srcDir(layout.buildDirectory.dir("generated/resources"))
+        kotlinMppExtension.sourceSets.matching { it.name == "frontendMain" }.configureEach {
+            resources.srcDir(kvExtension.generatedFrontendResources)
         }
 
         if (kvExtension.enableKsp.get()) {
@@ -226,15 +230,13 @@ abstract class KVisionPlugin @Inject constructor(
                 kotlinMppExtension.sourceSets.getByName("commonMain").kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
                 kotlinMppExtension.sourceSets.getByName("frontendMain").kotlin.srcDir("build/generated/ksp/frontend/frontendMain/kotlin")
                 kotlinMppExtension.sourceSets.getByName("backendMain").kotlin.srcDir("build/generated/ksp/backend/backendMain/kotlin")
+            }
 
-                afterEvaluate {
-                    tasks.all.kspKotlinFrontend.configureEach {
-                        dependsOn("kspCommonMainKotlinMetadata")
-                    }
-                    tasks.all.kspKotlinBackend.configureEach {
-                        dependsOn("kspCommonMainKotlinMetadata")
-                    }
-                }
+            tasks.all.kspKotlinFrontend.configureEach {
+                dependsOn("kspCommonMainKotlinMetadata")
+            }
+            tasks.all.kspKotlinBackend.configureEach {
+                dependsOn("kspCommonMainKotlinMetadata")
             }
         }
     }

--- a/kvision-tools/kvision-gradle-plugin/src/test/kotlin/io/kvision/gradle/MultiplatformTemplateTest.kt
+++ b/kvision-tools/kvision-gradle-plugin/src/test/kotlin/io/kvision/gradle/MultiplatformTemplateTest.kt
@@ -30,10 +30,8 @@ class MultiplatformTemplateTest : FunSpec({
                 result.output shouldContain "convertPoToJson"
             }
         }
-//
-// disabled temporarily
-//
-/*        test("verify generatePotFile task runs successfully") {
+
+        test("verify generatePotFile task runs successfully") {
             templateProjectDir.asClue { projectDir ->
                 val result = GradleRunner.create()
                     .withProjectDir(projectDir)
@@ -55,6 +53,6 @@ class MultiplatformTemplateTest : FunSpec({
 
                 result.output shouldContain "BUILD SUCCESSFUL"
             }
-        }*/
+        }
     }
 })

--- a/kvision-tools/kvision-gradle-plugin/src/test/kotlin/io/kvision/gradle/util/gradleTestKit.kt
+++ b/kvision-tools/kvision-gradle-plugin/src/test/kotlin/io/kvision/gradle/util/gradleTestKit.kt
@@ -8,19 +8,19 @@ import org.intellij.lang.annotations.Language
 
 class GradleKtsProjectDirBuilder {
 
-    @Language("kotlin")
+    @Language("kts")
     private var settingsGradleKts: String = """
         rootProject.name = "kvision-gradle-plugin-test"
     """.trimIndent()
 
-    @Language("kotlin")
+    @Language("kts")
     private var buildGradleKts: String = ""
 
-    fun `build gradle kts`(@Language("kotlin") contents: String) {
+    fun `build gradle kts`(@Language("kts") contents: String) {
         buildGradleKts = contents
     }
 
-    fun `settings gradle kts`(@Language("kotlin") contents: String) {
+    fun `settings gradle kts`(@Language("kts") contents: String) {
         settingsGradleKts = contents
     }
 


### PR DESCRIPTION
add KVision extension property for configuring generated resources dir

I also imagine that the `./build/generated/` directory is going to be popular, so I made it more specific. If it's still a problem, then users can change it to use another directory.

- used more lazy Gradle config
- improve `@Language` injection for Kotlin script
- un-disable po/pot task tests