### PR TITLE
Implement functionality on Tabulator, fixing Tabulator-downloading to CSV

### DIFF
--- a/kvision-modules/kvision-tabulator/src/main/kotlin/io/kvision/tabulator/Options.kt
+++ b/kvision-modules/kvision-tabulator/src/main/kotlin/io/kvision/tabulator/Options.kt
@@ -423,6 +423,12 @@ data class ColumnDefinition<T : Any>(
     val headerFilterLiveFilter: Boolean? = null,
     val htmlOutput: dynamic = null,
     val print: dynamic = null,
+    val formatterPrint: ((
+        cell: Tabulator.CellComponent,
+        formatterParams: dynamic,
+        onRendered: (callback: () -> Unit) -> Unit
+    ) -> dynamic)? = null,
+    val formatterPrintParams: dynamic = null,
     val cellClick: ((e: dynamic, cell: Tabulator.CellComponent) -> Unit)? = null,
     val cellDblClick: ((e: dynamic, cell: Tabulator.CellComponent) -> Unit)? = null,
     val cellContext: ((e: dynamic, cell: Tabulator.CellComponent) -> Unit)? = null,
@@ -627,6 +633,14 @@ fun <T : Any> ColumnDefinition<T>.toJs(
         if (headerFilterLiveFilter != null) this.headerFilterLiveFilter = headerFilterLiveFilter
         if (htmlOutput != null) this.htmlOutput = htmlOutput
         if (print != null) this.print = print
+        if (formatterPrint != null) this.formatterPrint = formatterPrint else {
+            if (formatterComponentFunction != null) {
+                this.formatterPrint = { cell: Tabulator.CellComponent, _: dynamic, _: () -> Unit ->
+                    cell.getValue()
+                }
+            }
+        }
+        if (formatterPrintParams != null) this.formatterPrintParams = formatterPrintParams
         if (cellClick != null) this.cellClick = cellClick
         if (cellDblClick != null) this.cellDblClick = cellDblClick
         if (cellContext != null) this.cellContext = cellContext

--- a/kvision-modules/kvision-tabulator/src/main/kotlin/io/kvision/tabulator/Tabulator.kt
+++ b/kvision-modules/kvision-tabulator/src/main/kotlin/io/kvision/tabulator/Tabulator.kt
@@ -456,12 +456,12 @@ open class Tabulator<T : Any>(
     ): Unit? {
         return if (newTab) {
             jsTabulator?.downloadToTab("csv", fileName, obj {
-                this.delimiter = delimiter
+                this.delimiter = delimiter.toString()
                 this.bom = includeBOM
             }, dataSet.set)
         } else {
             jsTabulator?.download("csv", fileName, obj {
-                this.delimiter = delimiter
+                this.delimiter = delimiter.toString()
                 this.bom = includeBOM
             }, dataSet.set)
         }
@@ -814,7 +814,7 @@ open class Tabulator<T : Any>(
         }
     }
 
-    internal fun toKotlinObjTabulator(data: dynamic, kClass: KClass<T>): T {
+    fun toKotlinObjTabulator(data: dynamic, kClass: KClass<T>): T {
         if (data._children != null) {
             data._children =
                 data._children.unsafeCast<Array<dynamic>>().map { toKotlinObjTabulator(it, kClass) }.toTypedArray()


### PR DESCRIPTION
Implemented _formatterPrint_ and _formatterPrintParams_ to allow using Tabulator printing capabilities when using _formatterComponentFunction_ on ColumnDefinition.

Also using a default value for _formatterPrint_ when _formatterComponentFunction_ is defined.

Fixed wrong exporting of CSV because the char delimiter was used with the ascii value, when a String value is required on the Tabulator implementation

Removed the _internal_ visibility modifier on the toKotlinObjTabulator() function, it's useful when need to convert the dynamic Tabulator value to a Kotlin object