### PR TITLE
! Fixed returning type of getSorters() function from Unit to Array<SorterFromTable>

### DIFF
--- a/kvision-modules/kvision-tabulator/src/main/kotlin/io/kvision/tabulator/js/Tabulator.kt
+++ b/kvision-modules/kvision-tabulator/src/main/kotlin/io/kvision/tabulator/js/Tabulator.kt
@@ -318,7 +318,7 @@ open external class Tabulator {
     open fun setSort(sortList: dynamic /* String | Array<Tabulator.Sorter> */, dir: String /* 'asc' | 'desc' */): Unit =
         definedExternally
 
-    open fun getSorters(): Unit = definedExternally
+    open fun getSorters(): Array<SorterFromTable> = definedExternally
     open fun clearSort(): Unit = definedExternally
     open fun setFilter(
         p1: dynamic /* String | Array<Tabulator.Filter> | Array<Any> | (data: Any, filterParams: Any):Boolean */,


### PR DESCRIPTION
According to current Tabulator documentation:

`table.getSorters();
`

"This will return an array of sort objects with three properties, column the column component for the sorted column, field a string of the field name for the sorted column, and dir a string of either "asc" or "desc" indicating the direction of sort."

Class SorterFromTable is already defined on KVision sources.