### PR TITLE
use value class to improve StyledComponent constructor time

### DIFF
--- a/src/jsMain/kotlin/io/kvision/core/Style.kt
+++ b/src/jsMain/kotlin/io/kvision/core/Style.kt
@@ -86,7 +86,7 @@ open class Style(
     val parentStyle: Style? = null,
     init: (Style.() -> Unit)? = null
 ) : StyledComponent() {
-    private val propertyValues = js("{}")
+    internal val stylePropertyValues = js("{}")
 
     /**
      * The name of the CSS selector.
@@ -150,7 +150,7 @@ open class Style(
 
     @Suppress("NOTHING_TO_INLINE")
     protected inline fun <T> refreshOnUpdate(noinline refreshFunction: ((T) -> Unit) = { this.refresh() }) =
-        RefreshDelegateProvider<T>(null, refreshFunction)
+        RefreshDelegate(refreshFunction)
 
     @Suppress("NOTHING_TO_INLINE")
     protected inline fun <T> refreshOnUpdate(
@@ -163,30 +163,30 @@ open class Style(
         private val initialValue: T?, private val refreshFunction: (T) -> Unit
     ) {
         operator fun provideDelegate(thisRef: Any?, prop: KProperty<*>): RefreshDelegate<T> {
-            if (initialValue != null) propertyValues[prop.name] = initialValue
+            if (initialValue != null) stylePropertyValues[prop.name] = initialValue
             return RefreshDelegate(refreshFunction)
-        }
-    }
-
-    protected inner class RefreshDelegate<T>(private val refreshFunction: ((T) -> Unit)) {
-        operator fun getValue(thisRef: StyledComponent, property: KProperty<*>): T {
-            val value = propertyValues[property.name]
-            return if (value != null) {
-                value.unsafeCast<T>()
-            } else {
-                null.unsafeCast<T>()
-            }
-        }
-
-        operator fun setValue(thisRef: StyledComponent, property: KProperty<*>, value: T) {
-            propertyValues[property.name] = value
-            refreshFunction(value)
         }
     }
 
     companion object {
         internal var counter = 0
         internal var styles = mutableListOf<Style>()
+    }
+}
+
+class RefreshDelegate<T>(private val refreshFunction: ((T) -> Unit)) {
+    operator fun getValue(thisRef: Style, property: KProperty<*>): T {
+        val value = thisRef.stylePropertyValues[property.name]
+        return if (value != null) {
+            value.unsafeCast<T>()
+        } else {
+            null.unsafeCast<T>()
+        }
+    }
+
+    operator fun setValue(thisRef: Style, property: KProperty<*>, value: T) {
+        thisRef.stylePropertyValues[property.name] = value
+        refreshFunction(value)
     }
 }
 


### PR DESCRIPTION
I noticed while profiling that it was taking a significant amount of time to construct components on one of my projects with a very large dom. by making the delegate for refreshOnUpdate a value class, and directly supplying it when there is no initial value, it can get inlined. therefore allowing for less construction and storing of the delegate classes on the objects.

by very large I mean
![image](https://github.com/rjaros/kvision/assets/6234704/8f89c57c-2df6-447f-8ebc-533af4a2b6f2)

before:
![image](https://github.com/rjaros/kvision/assets/6234704/384feb4d-f2e4-4d8e-9048-2a5da0dabe3b)
![image](https://github.com/rjaros/kvision/assets/6234704/130a217e-7434-4424-a404-865e675019ac)

after:
![image](https://github.com/rjaros/kvision/assets/6234704/9388e0ee-2047-41c1-ab2d-6a2e83dd1a90)
![image](https://github.com/rjaros/kvision/assets/6234704/8a10d2af-f9f5-4c77-92c5-4f15a3445f26)

profiling was done on Chrome on my linux desktop.