### PR TITLE
Add support for Spring Boot Web MVC (for building a fat/uber jar)

### DIFF
--- a/kvision-tools/kvision-gradle-plugin/src/main/kotlin/io/kvision/gradle/KVisionPlugin.kt
+++ b/kvision-tools/kvision-gradle-plugin/src/main/kotlin/io/kvision/gradle/KVisionPlugin.kt
@@ -38,7 +38,7 @@ import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpack
 import org.jetbrains.kotlin.gradle.targets.js.yarn.YarnRootExtension
 import org.springframework.boot.gradle.tasks.bundling.BootJar
 import org.springframework.boot.gradle.tasks.run.BootRun
-import java.util.*
+import java.util.Properties
 import javax.inject.Inject
 
 
@@ -602,6 +602,9 @@ abstract class KVisionPlugin @Inject constructor(
         get() = named("jsMain")
 
     private fun getServerType(project: Project): KVServerType? {
+        if (project.configurations["jvmMainImplementation"].dependencies.any { it.name == "spring-boot-starter-web" }) {
+            return KVServerType.SPRINGBOOT
+        }
         val kvisionServerDependency = project.configurations["commonMainApi"].dependencies.map {
             it.name
         }.firstOrNull { it.startsWith("kvision-server-") }


### PR DESCRIPTION
I am building a fullstack KMP web application with your nice and extensive kvision framework. I decided to use Spring Boot Web MVC in favor of the reactive stack (WebFlux) because I need to use Hibernate and I think Spring Boot Web MVC combined with java's virtual threads is better future-proof than Spring Boot reactive (because of its complexity/overhead with project reactor base).

My addition adds recognition of Spring Boot Web MVC to get the benefits of your gradle tasks code to build a fat jar containing the backend and the frontend code.
(The use of your KMP code generation does not work with Spring Boot Web MVC, this is not a big issue because I used standard RestController and a small coroutines frontend client. Code generation would also be desirable for this use case in the future).

I would be very happy if this feature could be included.