### PR TITLE
Add FormFieldConverter and dataOverlayProvider to Form/FormPanel

### DIFF
--- a/kvision/src/jsMain/kotlin/io/kvision/form/Form.kt
+++ b/kvision/src/jsMain/kotlin/io/kvision/form/Form.kt
@@ -72,6 +72,21 @@ class Form<K : Any>(
     internal val fieldsParams: MutableMap<String, Any> = mutableMapOf()
     internal var validatorMessage: ((Form<K>) -> String?)? = null
     internal var validator: ((Form<K>) -> Boolean?)? = null
+    private val fieldConverters: MutableMap<String, FormFieldConverter> = mutableMapOf()
+
+    /**
+     * Optional provider for additional data to merge into [getData] results.
+     * Allows external components (e.g. tabulators, custom editors) to participate
+     * in form data collection without being [FormControl] instances.
+     * Overlay values take precedence over field values on key conflicts.
+     *
+     * **Note:** Overlay values are not subject to form validation. They are injected
+     * directly into the data model during [getData], after [validate] has been called.
+     * Null overlay values are skipped (consistent with field null handling).
+     * All overlay keys must correspond to properties in the `@Serializable` model class;
+     * unknown keys will cause a deserialization error.
+     */
+    var dataOverlayProvider: (() -> Map<String, Any?>)? = null
 
     @OptIn(ExperimentalSerializationApi::class)
     private val JsonInstance = serializer?.let {
@@ -94,19 +109,30 @@ class Form<K : Any>(
             {
                 val json = js("{}")
                 it.forEach { (key, value) ->
-                    val v = when (value) {
-                        is Date -> {
-                            value.toStringF()
-                        }
+                    val converter = fieldConverters[key]
+                    val v = if (converter != null) {
+                        converter.toJson(value)
+                    } else {
+                        when (value) {
+                            is Date -> {
+                                value.toStringF()
+                            }
 
-                        is List<*> -> {
-                            @Suppress("UNCHECKED_CAST")
-                            ((value as? List<KFile>)?.toObj(ListSerializer(KFile.serializer())))
-                        }
+                            is List<*> -> {
+                                @Suppress("UNCHECKED_CAST")
+                                ((value as? List<KFile>)?.toObj(ListSerializer(KFile.serializer())))
+                            }
 
-                        else -> value
+                            else -> value
+                        }
                     }
                     if (v != null) json[key] = v
+                }
+                // Merge overlay values directly into the JSON object, bypassing converter/type dispatch.
+                // Overlay values are already in the correct format for serialization.
+                // Null overlay values are skipped (consistent with field null handling above).
+                dataOverlayProvider?.invoke()?.forEach { (key, value) ->
+                    if (value != null) json[key] = value
                 }
                 JsonInstance!!.decodeFromString(serializer, JSON.stringify(json))
             }
@@ -119,21 +145,26 @@ class Form<K : Any>(
     }
 
     /**
-     * Adds a form control to the form with a dynamic keys.
+     * Adds a form control to the form with a dynamic key.
      * @param key key identifier of the control
      * @param control the form control
      * @param required determines if the control is required
      * @param requiredMessage optional required validation message
+     * @param converter optional field converter for custom type handling
      * @param validatorMessage optional function returning validation message
      * @param validator optional validation function
      */
     fun <C : FormControl> add(
         key: String, control: C, required: Boolean = false, requiredMessage: String? = null,
+        converter: FormFieldConverter? = null,
         validatorMessage: ((C) -> String?)? = null,
         validator: ((C) -> Boolean?)? = null
     ) {
         this.fields[key] = control
         this.fieldsParams[key] = FieldParams(required, requiredMessage, validatorMessage, validator)
+        if (converter != null) {
+            this.fieldConverters[key] = converter
+        }
     }
 
     /**
@@ -142,15 +173,17 @@ class Form<K : Any>(
      * @param control the string form control
      * @param required determines if the control is required
      * @param requiredMessage optional required validation message
+     * @param converter optional field converter for custom type handling
      * @param validatorMessage optional function returning validation message
      * @param validator optional validation function
      */
     fun <C : StringFormControl> add(
         key: KProperty1<K, String?>, control: C, required: Boolean = false, requiredMessage: String? = null,
+        converter: FormFieldConverter? = null,
         validatorMessage: ((C) -> String?)? = null,
         validator: ((C) -> Boolean?)? = null
     ) {
-        add(key.name, control, required, requiredMessage, validatorMessage, validator)
+        add(key.name, control, required, requiredMessage, converter, validatorMessage, validator)
     }
 
     /**
@@ -159,15 +192,17 @@ class Form<K : Any>(
      * @param control the string form control
      * @param required determines if the control is required
      * @param requiredMessage optional required validation message
+     * @param converter optional field converter for custom type handling
      * @param validatorMessage optional function returning validation message
      * @param validator optional validation function
      */
     fun <C : StringFormControl> addCustom(
         key: KProperty1<K, Any?>, control: C, required: Boolean = false, requiredMessage: String? = null,
+        converter: FormFieldConverter? = null,
         validatorMessage: ((C) -> String?)? = null,
         validator: ((C) -> Boolean?)? = null
     ) {
-        add(key.name, control, required, requiredMessage, validatorMessage, validator)
+        add(key.name, control, required, requiredMessage, converter, validatorMessage, validator)
     }
 
     /**
@@ -176,15 +211,17 @@ class Form<K : Any>(
      * @param control the boolean form control
      * @param required determines if the control is required
      * @param requiredMessage optional required validation message
+     * @param converter optional field converter for custom type handling
      * @param validatorMessage optional function returning validation message
      * @param validator optional validation function
      */
     fun <C : BoolFormControl> add(
         key: KProperty1<K, Boolean?>, control: C, required: Boolean = false, requiredMessage: String? = null,
+        converter: FormFieldConverter? = null,
         validatorMessage: ((C) -> String?)? = null,
         validator: ((C) -> Boolean?)? = null
     ) {
-        add(key.name, control, required, requiredMessage, validatorMessage, validator)
+        add(key.name, control, required, requiredMessage, converter, validatorMessage, validator)
     }
 
     /**
@@ -193,15 +230,17 @@ class Form<K : Any>(
      * @param control the boolean form control
      * @param required determines if the control is required
      * @param requiredMessage optional required validation message
+     * @param converter optional field converter for custom type handling
      * @param validatorMessage optional function returning validation message
      * @param validator optional validation function
      */
     fun <C : TriStateFormControl> add(
         key: KProperty1<K, Boolean?>, control: C, required: Boolean = false, requiredMessage: String? = null,
+        converter: FormFieldConverter? = null,
         validatorMessage: ((C) -> String?)? = null,
         validator: ((C) -> Boolean?)? = null
     ) {
-        add(key.name, control, required, requiredMessage, validatorMessage, validator)
+        add(key.name, control, required, requiredMessage, converter, validatorMessage, validator)
     }
 
     /**
@@ -210,15 +249,17 @@ class Form<K : Any>(
      * @param control the number form control
      * @param required determines if the control is required
      * @param requiredMessage optional required validation message
+     * @param converter optional field converter for custom type handling
      * @param validatorMessage optional function returning validation message
      * @param validator optional validation function
      */
     fun <C : NumberFormControl> add(
         key: KProperty1<K, Number?>, control: C, required: Boolean = false, requiredMessage: String? = null,
+        converter: FormFieldConverter? = null,
         validatorMessage: ((C) -> String?)? = null,
         validator: ((C) -> Boolean?)? = null
     ) {
-        add(key.name, control, required, requiredMessage, validatorMessage, validator)
+        add(key.name, control, required, requiredMessage, converter, validatorMessage, validator)
     }
 
     /**
@@ -227,15 +268,17 @@ class Form<K : Any>(
      * @param control the date form control
      * @param required determines if the control is required
      * @param requiredMessage optional required validation message
+     * @param converter optional field converter for custom type handling
      * @param validatorMessage optional function returning validation message
      * @param validator optional validation function
      */
     fun <C : DateFormControl> add(
         key: KProperty1<K, Date?>, control: C, required: Boolean = false, requiredMessage: String? = null,
+        converter: FormFieldConverter? = null,
         validatorMessage: ((C) -> String?)? = null,
         validator: ((C) -> Boolean?)? = null
     ) {
-        add(key.name, control, required, requiredMessage, validatorMessage, validator)
+        add(key.name, control, required, requiredMessage, converter, validatorMessage, validator)
     }
 
     /**
@@ -244,15 +287,51 @@ class Form<K : Any>(
      * @param control the files form control
      * @param required determines if the control is required
      * @param requiredMessage optional required validation message
+     * @param converter optional field converter for custom type handling
      * @param validatorMessage optional function returning validation message
      * @param validator optional validation function
      */
     fun <C : KFilesFormControl> add(
         key: KProperty1<K, List<KFile>?>, control: C, required: Boolean = false, requiredMessage: String? = null,
+        converter: FormFieldConverter? = null,
         validatorMessage: ((C) -> String?)? = null,
         validator: ((C) -> Boolean?)? = null
     ) {
-        add(key.name, control, required, requiredMessage, validatorMessage, validator)
+        add(key.name, control, required, requiredMessage, converter, validatorMessage, validator)
+    }
+
+    /**
+     * Registers a field converter for the given key.
+     * @param key key identifier of the control
+     * @param converter the field converter
+     */
+    fun registerConverter(key: String, converter: FormFieldConverter) {
+        fieldConverters[key] = converter
+    }
+
+    /**
+     * Registers a field converter for the given property.
+     * @param key property reference used as the control identifier
+     * @param converter the field converter
+     */
+    fun registerConverter(key: KProperty1<K, *>, converter: FormFieldConverter) {
+        fieldConverters[key.name] = converter
+    }
+
+    /**
+     * Removes a field converter for the given key.
+     * @param key key identifier of the control
+     */
+    fun removeConverter(key: String) {
+        fieldConverters.remove(key)
+    }
+
+    /**
+     * Removes a field converter for the given property.
+     * @param key property reference used as the control identifier
+     */
+    fun removeConverter(key: KProperty1<K, *>) {
+        fieldConverters.remove(key.name)
     }
 
     /**
@@ -261,14 +340,16 @@ class Form<K : Any>(
      */
     fun remove(key: KProperty1<K, *>) {
         this.fields.remove(key.name)
+        this.fieldConverters.remove(key.name)
     }
 
     /**
-     * Removes a control from the form with a dynamic keys.
+     * Removes a control from the form with a dynamic key.
      * @param key key identifier of the control
      */
     fun remove(key: String) {
         this.fields.remove(key)
+        this.fieldConverters.remove(key)
     }
 
     /**
@@ -276,6 +357,7 @@ class Form<K : Any>(
      */
     fun removeAll() {
         this.fields.clear()
+        this.fieldConverters.clear()
     }
 
     /**
@@ -334,20 +416,28 @@ class Form<K : Any>(
             for (key in keys) {
                 val jsonValue = json[key]
                 if (jsonValue != null) {
-                    when (val formField = fields[key]) {
-                        is DateFormControl -> formField.value = (jsonValue.unsafeCast<String>()).toDateF()
-                        is KFilesFormControl -> {
-                            formField.value = Serialization.plain.decodeFromString(
-                                ListSerializer(KFile.serializer()),
-                                JSON.stringify(jsonValue)
-                            )
-                        }
+                    val formField = fields[key]
+                    val converter = fieldConverters[key]
+                    if (converter != null && formField != null) {
+                        formField.setValue(converter.fromJson(jsonValue))
+                    } else {
+                        when (formField) {
+                            is DateFormControl -> formField.value =
+                                (jsonValue.unsafeCast<String>()).toDateF()
 
-                        else -> {
-                            if (formField != null) {
-                                formField.setValue(jsonValue)
-                            } else {
-                                dataMap[key] = jsonValue
+                            is KFilesFormControl -> {
+                                formField.value = Serialization.plain.decodeFromString(
+                                    ListSerializer(KFile.serializer()),
+                                    JSON.stringify(jsonValue)
+                                )
+                            }
+
+                            else -> {
+                                if (formField != null) {
+                                    formField.setValue(jsonValue)
+                                } else {
+                                    dataMap[key] = jsonValue
+                                }
                             }
                         }
                     }
@@ -357,11 +447,15 @@ class Form<K : Any>(
             }
             fields.forEach { if (!keys.contains(it.key)) it.value.setValue(null) }
         } else {
+            // Non-serializer path: check converters before falling back to default setValue
             val map = model.unsafeCast<Map<String, Any?>>()
             map.forEach { (key, value) ->
                 if (value != null) {
                     val formField = fields[key]
-                    if (formField != null) {
+                    val converter = fieldConverters[key]
+                    if (converter != null && formField != null) {
+                        formField.setValue(converter.fromJson(value))
+                    } else if (formField != null) {
                         formField.setValue(value)
                     } else {
                         dataMap[key] = value
@@ -384,11 +478,27 @@ class Form<K : Any>(
 
     /**
      * Returns current data model.
+     *
+     * Field values are collected from form controls, with converters applied where registered.
+     * If a [dataOverlayProvider] is set, overlay values are merged after field processing
+     * and bypass converter/type dispatch (they must already be in the correct format).
+     *
      * @return data model
      */
     fun getData(): K {
-        val map = dataMap + fields.entries.associateBy({ it.key }, { it.value.getValue() })
-        return modelFactory?.invoke(map.withDefault { null }) ?: map.unsafeCast<K>()
+        val fieldValues = fields.entries.associateBy({ it.key }, { it.value.getValue() })
+        val map = dataMap + fieldValues
+        return modelFactory?.invoke(map.withDefault { null }) ?: run {
+            // Non-serializer path: apply converters and merge overlay
+            val converted = fieldValues.entries.associate { (key, value) ->
+                val converter = fieldConverters[key]
+                key to if (converter != null) converter.toJson(value) else value
+            }
+            val base = dataMap + converted
+            val overlay = dataOverlayProvider?.invoke()?.filterValues { it != null } ?: emptyMap()
+            val merged = if (overlay.isEmpty()) base else base + overlay
+            merged.unsafeCast<K>()
+        }
     }
 
     /**

--- a/kvision/src/jsMain/kotlin/io/kvision/form/FormFieldConverter.kt
+++ b/kvision/src/jsMain/kotlin/io/kvision/form/FormFieldConverter.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2017-present Robert Jaros
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.kvision.form
+
+/**
+ * Converts between a model property value and the form control's
+ * value/JSON representation. Registered per-field via [Form.add] or
+ * [Form.registerConverter] to handle custom types beyond the built-in
+ * String/Number/Boolean/Date/KFiles.
+ */
+interface FormFieldConverter {
+    /**
+     * Convert a JSON-dynamic value (from the serialized model) to the value
+     * expected by [FormControl.setValue].
+     * Called during [Form.setData] to populate form controls.
+     *
+     * @param jsonValue the dynamic JSON value from the serialized model
+     * @return the value to pass to FormControl.setValue()
+     */
+    fun fromJson(jsonValue: dynamic): Any?
+
+    /**
+     * Convert a [FormControl.getValue] result to a JSON-dynamic value
+     * suitable for model deserialization.
+     * Called during [Form.getData] to collect form values.
+     *
+     * @param controlValue the value returned by FormControl.getValue()
+     * @return the dynamic JSON value for model deserialization
+     */
+    fun toJson(controlValue: Any?): dynamic
+}

--- a/kvision/src/jsMain/kotlin/io/kvision/form/FormPanel.kt
+++ b/kvision/src/jsMain/kotlin/io/kvision/form/FormPanel.kt
@@ -193,6 +193,24 @@ open class FormPanel<K : Any>(
         }
 
     /**
+     * Optional provider for additional data to merge into [getData] results.
+     * Allows external components (e.g. tabulators, custom editors) to participate
+     * in form data collection without being [FormControl] instances.
+     * Overlay values take precedence over field values on key conflicts.
+     *
+     * **Note:** Overlay values are not subject to form validation. They are injected
+     * directly into the data model during [getData], after [validate] has been called.
+     * Null overlay values are skipped (consistent with field null handling).
+     * All overlay keys must correspond to properties in the `@Serializable` model class;
+     * unknown keys will cause a deserialization error.
+     */
+    var dataOverlayProvider
+        get() = form.dataOverlayProvider
+        set(value) {
+            form.dataOverlayProvider = value
+        }
+
+    /**
      * @suppress
      * Internal property.
      */
@@ -255,12 +273,14 @@ open class FormPanel<K : Any>(
      * @param required determines if the control is required
      * @param requiredMessage optional required validation message
      * @param legend put this control inside a fieldset with given legend
+     * @param converter optional field converter for custom type handling
      * @param validatorMessage optional function returning validation message
      * @param validator optional validation function
      */
     open fun <C : FormControl> add(
         key: String, control: C, required: Boolean = false, requiredMessage: String? = null,
         legend: String? = null,
+        converter: FormFieldConverter? = null,
         validatorMessage: ((C) -> String?)? = null,
         validator: ((C) -> Boolean?)? = null
     ) {
@@ -280,7 +300,7 @@ open class FormPanel<K : Any>(
         } else {
             currentFieldset?.add(control)
         }
-        form.add(key, control, required, requiredMessage, validatorMessage, validator)
+        form.add(key, control, required, requiredMessage, converter, validatorMessage, validator)
     }
 
     override fun add(child: Component) {
@@ -301,16 +321,18 @@ open class FormPanel<K : Any>(
      * @param required determines if the control is required
      * @param requiredMessage optional required validation message
      * @param legend put this control inside a fieldset with given legend
+     * @param converter optional field converter for custom type handling
      * @param validatorMessage optional function returning validation message
      * @param validator optional validation function
      */
     open fun <C : StringFormControl> add(
         key: KProperty1<K, String?>, control: C, required: Boolean = false, requiredMessage: String? = null,
         legend: String? = null,
+        converter: FormFieldConverter? = null,
         validatorMessage: ((C) -> String?)? = null,
         validator: ((C) -> Boolean?)? = null
     ) {
-        add(key.name, control, required, requiredMessage, legend, validatorMessage, validator)
+        add(key.name, control, required, requiredMessage, legend, converter, validatorMessage, validator)
     }
 
     /**
@@ -320,16 +342,18 @@ open class FormPanel<K : Any>(
      * @param required determines if the control is required
      * @param requiredMessage optional required validation message
      * @param legend put this control inside a fieldset with given legend
+     * @param converter optional field converter for custom type handling
      * @param validatorMessage optional function returning validation message
      * @param validator optional validation function
      */
     open fun <C : StringFormControl> addCustom(
         key: KProperty1<K, Any?>, control: C, required: Boolean = false, requiredMessage: String? = null,
         legend: String? = null,
+        converter: FormFieldConverter? = null,
         validatorMessage: ((C) -> String?)? = null,
         validator: ((C) -> Boolean?)? = null
     ) {
-        add(key.name, control, required, requiredMessage, legend, validatorMessage, validator)
+        add(key.name, control, required, requiredMessage, legend, converter, validatorMessage, validator)
     }
 
     /**
@@ -339,16 +363,18 @@ open class FormPanel<K : Any>(
      * @param required determines if the control is required
      * @param requiredMessage optional required validation message
      * @param legend put this control inside a fieldset with given legend
+     * @param converter optional field converter for custom type handling
      * @param validatorMessage optional function returning validation message
      * @param validator optional validation function
      */
     open fun <C : BoolFormControl> add(
         key: KProperty1<K, Boolean?>, control: C, required: Boolean = false, requiredMessage: String? = null,
         legend: String? = null,
+        converter: FormFieldConverter? = null,
         validatorMessage: ((C) -> String?)? = null,
         validator: ((C) -> Boolean?)? = null
     ) {
-        add(key.name, control, required, requiredMessage, legend, validatorMessage, validator)
+        add(key.name, control, required, requiredMessage, legend, converter, validatorMessage, validator)
     }
 
     /**
@@ -358,16 +384,18 @@ open class FormPanel<K : Any>(
      * @param required determines if the control is required
      * @param requiredMessage optional required validation message
      * @param legend put this control inside a fieldset with given legend
+     * @param converter optional field converter for custom type handling
      * @param validatorMessage optional function returning validation message
      * @param validator optional validation function
      */
     open fun <C : TriStateFormControl> add(
         key: KProperty1<K, Boolean?>, control: C, required: Boolean = false, requiredMessage: String? = null,
         legend: String? = null,
+        converter: FormFieldConverter? = null,
         validatorMessage: ((C) -> String?)? = null,
         validator: ((C) -> Boolean?)? = null
     ) {
-        add(key.name, control, required, requiredMessage, legend, validatorMessage, validator)
+        add(key.name, control, required, requiredMessage, legend, converter, validatorMessage, validator)
     }
 
     /**
@@ -377,16 +405,18 @@ open class FormPanel<K : Any>(
      * @param required determines if the control is required
      * @param requiredMessage optional required validation message
      * @param legend put this control inside a fieldset with given legend
+     * @param converter optional field converter for custom type handling
      * @param validatorMessage optional function returning validation message
      * @param validator optional validation function
      */
     open fun <C : NumberFormControl> add(
         key: KProperty1<K, Number?>, control: C, required: Boolean = false, requiredMessage: String? = null,
         legend: String? = null,
+        converter: FormFieldConverter? = null,
         validatorMessage: ((C) -> String?)? = null,
         validator: ((C) -> Boolean?)? = null
     ) {
-        add(key.name, control, required, requiredMessage, legend, validatorMessage, validator)
+        add(key.name, control, required, requiredMessage, legend, converter, validatorMessage, validator)
     }
 
     /**
@@ -396,16 +426,18 @@ open class FormPanel<K : Any>(
      * @param required determines if the control is required
      * @param requiredMessage optional required validation message
      * @param legend put this control inside a fieldset with given legend
+     * @param converter optional field converter for custom type handling
      * @param validatorMessage optional function returning validation message
      * @param validator optional validation function
      */
     open fun <C : DateFormControl> add(
         key: KProperty1<K, Date?>, control: C, required: Boolean = false, requiredMessage: String? = null,
         legend: String? = null,
+        converter: FormFieldConverter? = null,
         validatorMessage: ((C) -> String?)? = null,
         validator: ((C) -> Boolean?)? = null
     ) {
-        add(key.name, control, required, requiredMessage, legend, validatorMessage, validator)
+        add(key.name, control, required, requiredMessage, legend, converter, validatorMessage, validator)
     }
 
     /**
@@ -415,16 +447,18 @@ open class FormPanel<K : Any>(
      * @param required determines if the control is required
      * @param requiredMessage optional required validation message
      * @param legend put this control inside a fieldset with given legend
+     * @param converter optional field converter for custom type handling
      * @param validatorMessage optional function returning validation message
      * @param validator optional validation function
      */
     open fun <C : KFilesFormControl> add(
         key: KProperty1<K, List<KFile>?>, control: C, required: Boolean = false, requiredMessage: String? = null,
         legend: String? = null,
+        converter: FormFieldConverter? = null,
         validatorMessage: ((C) -> String?)? = null,
         validator: ((C) -> Boolean?)? = null
     ) {
-        add(key.name, control, required, requiredMessage, legend, validatorMessage, validator)
+        add(key.name, control, required, requiredMessage, legend, converter, validatorMessage, validator)
     }
 
     /**
@@ -433,6 +467,7 @@ open class FormPanel<K : Any>(
      * @param required determines if the control is required
      * @param requiredMessage optional required validation message
      * @param layoutType style control for given form layout
+     * @param converter optional field converter for custom type handling
      * @param validatorMessage optional function returning validation message
      * @param validator optional validation function
      * @return the control itself
@@ -440,6 +475,7 @@ open class FormPanel<K : Any>(
     open fun <C : FormControl> C.bind(
         key: String, required: Boolean = false, requiredMessage: String? = null,
         layoutType: FormType? = null,
+        converter: FormFieldConverter? = null,
         validatorMessage: ((C) -> String?)? = null,
         validator: ((C) -> Boolean?)? = null
     ): C {
@@ -449,7 +485,7 @@ open class FormPanel<K : Any>(
             else -> this.styleForVerticalFormPanel()
         }
         if (required) this.flabel.addCssClass("required-label")
-        form.add(key, this, required, requiredMessage, validatorMessage, validator)
+        form.add(key, this, required, requiredMessage, converter, validatorMessage, validator)
         return this
     }
 
@@ -459,6 +495,7 @@ open class FormPanel<K : Any>(
      * @param required determines if the control is required
      * @param requiredMessage optional required validation message
      * @param layoutType style control for given form layout
+     * @param converter optional field converter for custom type handling
      * @param validatorMessage optional function returning validation message
      * @param validator optional validation function
      * @return the control itself
@@ -466,10 +503,11 @@ open class FormPanel<K : Any>(
     open fun <C : StringFormControl> C.bind(
         key: KProperty1<K, String?>, required: Boolean = false, requiredMessage: String? = null,
         layoutType: FormType? = null,
+        converter: FormFieldConverter? = null,
         validatorMessage: ((C) -> String?)? = null,
         validator: ((C) -> Boolean?)? = null
     ): C {
-        return bind(key.name, required, requiredMessage, layoutType, validatorMessage, validator)
+        return bind(key.name, required, requiredMessage, layoutType, converter, validatorMessage, validator)
     }
 
     /**
@@ -478,6 +516,7 @@ open class FormPanel<K : Any>(
      * @param required determines if the control is required
      * @param requiredMessage optional required validation message
      * @param layoutType style control for given form layout
+     * @param converter optional field converter for custom type handling
      * @param validatorMessage optional function returning validation message
      * @param validator optional validation function
      * @return the control itself
@@ -485,10 +524,11 @@ open class FormPanel<K : Any>(
     open fun <C : StringFormControl> C.bindCustom(
         key: KProperty1<K, Any?>, required: Boolean = false, requiredMessage: String? = null,
         layoutType: FormType? = null,
+        converter: FormFieldConverter? = null,
         validatorMessage: ((C) -> String?)? = null,
         validator: ((C) -> Boolean?)? = null
     ): C {
-        return bind(key.name, required, requiredMessage, layoutType, validatorMessage, validator)
+        return bind(key.name, required, requiredMessage, layoutType, converter, validatorMessage, validator)
     }
 
 
@@ -498,6 +538,7 @@ open class FormPanel<K : Any>(
      * @param required determines if the control is required
      * @param requiredMessage optional required validation message
      * @param layoutType style control for given form layout
+     * @param converter optional field converter for custom type handling
      * @param validatorMessage optional function returning validation message
      * @param validator optional validation function
      * @return the control itself
@@ -505,10 +546,11 @@ open class FormPanel<K : Any>(
     open fun <C : BoolFormControl> C.bind(
         key: KProperty1<K, Boolean?>, required: Boolean = false, requiredMessage: String? = null,
         layoutType: FormType? = null,
+        converter: FormFieldConverter? = null,
         validatorMessage: ((C) -> String?)? = null,
         validator: ((C) -> Boolean?)? = null
     ): C {
-        return bind(key.name, required, requiredMessage, layoutType, validatorMessage, validator)
+        return bind(key.name, required, requiredMessage, layoutType, converter, validatorMessage, validator)
     }
 
     /**
@@ -517,6 +559,7 @@ open class FormPanel<K : Any>(
      * @param required determines if the control is required
      * @param requiredMessage optional required validation message
      * @param layoutType style control for given form layout
+     * @param converter optional field converter for custom type handling
      * @param validatorMessage optional function returning validation message
      * @param validator optional validation function
      * @return the control itself
@@ -524,10 +567,11 @@ open class FormPanel<K : Any>(
     open fun <C : TriStateFormControl> C.bind(
         key: KProperty1<K, Boolean?>, required: Boolean = false, requiredMessage: String? = null,
         layoutType: FormType? = null,
+        converter: FormFieldConverter? = null,
         validatorMessage: ((C) -> String?)? = null,
         validator: ((C) -> Boolean?)? = null
     ): C {
-        return bind(key.name, required, requiredMessage, layoutType, validatorMessage, validator)
+        return bind(key.name, required, requiredMessage, layoutType, converter, validatorMessage, validator)
     }
 
     /**
@@ -536,6 +580,7 @@ open class FormPanel<K : Any>(
      * @param required determines if the control is required
      * @param requiredMessage optional required validation message
      * @param layoutType style control for given form layout
+     * @param converter optional field converter for custom type handling
      * @param validatorMessage optional function returning validation message
      * @param validator optional validation function
      * @return the control itself
@@ -543,10 +588,11 @@ open class FormPanel<K : Any>(
     open fun <C : NumberFormControl> C.bind(
         key: KProperty1<K, Number?>, required: Boolean = false, requiredMessage: String? = null,
         layoutType: FormType? = null,
+        converter: FormFieldConverter? = null,
         validatorMessage: ((C) -> String?)? = null,
         validator: ((C) -> Boolean?)? = null
     ): C {
-        return bind(key.name, required, requiredMessage, layoutType, validatorMessage, validator)
+        return bind(key.name, required, requiredMessage, layoutType, converter, validatorMessage, validator)
     }
 
     /**
@@ -555,6 +601,7 @@ open class FormPanel<K : Any>(
      * @param required determines if the control is required
      * @param requiredMessage optional required validation message
      * @param layoutType style control for given form layout
+     * @param converter optional field converter for custom type handling
      * @param validatorMessage optional function returning validation message
      * @param validator optional validation function
      * @return the control itself
@@ -562,10 +609,11 @@ open class FormPanel<K : Any>(
     open fun <C : DateFormControl> C.bind(
         key: KProperty1<K, Date?>, required: Boolean = false, requiredMessage: String? = null,
         layoutType: FormType? = null,
+        converter: FormFieldConverter? = null,
         validatorMessage: ((C) -> String?)? = null,
         validator: ((C) -> Boolean?)? = null
     ): C {
-        return bind(key.name, required, requiredMessage, layoutType, validatorMessage, validator)
+        return bind(key.name, required, requiredMessage, layoutType, converter, validatorMessage, validator)
     }
 
     /**
@@ -574,6 +622,7 @@ open class FormPanel<K : Any>(
      * @param required determines if the control is required
      * @param requiredMessage optional required validation message
      * @param layoutType style control for given form layout
+     * @param converter optional field converter for custom type handling
      * @param validatorMessage optional function returning validation message
      * @param validator optional validation function
      * @return the control itself
@@ -581,10 +630,11 @@ open class FormPanel<K : Any>(
     open fun <C : KFilesFormControl> C.bind(
         key: KProperty1<K, List<KFile>?>, required: Boolean = false, requiredMessage: String? = null,
         layoutType: FormType? = null,
+        converter: FormFieldConverter? = null,
         validatorMessage: ((C) -> String?)? = null,
         validator: ((C) -> Boolean?)? = null
     ): C {
-        return bind(key.name, required, requiredMessage, layoutType, validatorMessage, validator)
+        return bind(key.name, required, requiredMessage, layoutType, converter, validatorMessage, validator)
     }
 
     /**
@@ -630,6 +680,40 @@ open class FormPanel<K : Any>(
      */
     open fun unbind(key: String) {
         form.remove(key)
+    }
+
+    /**
+     * Registers a field converter for the given key.
+     * @param key key identifier of the control
+     * @param converter the field converter
+     */
+    open fun registerConverter(key: String, converter: FormFieldConverter) {
+        form.registerConverter(key, converter)
+    }
+
+    /**
+     * Registers a field converter for the given property.
+     * @param key property reference used as the control identifier
+     * @param converter the field converter
+     */
+    open fun registerConverter(key: KProperty1<K, *>, converter: FormFieldConverter) {
+        form.registerConverter(key, converter)
+    }
+
+    /**
+     * Removes a field converter for the given key.
+     * @param key key identifier of the control
+     */
+    open fun removeConverter(key: String) {
+        form.removeConverter(key)
+    }
+
+    /**
+     * Removes a field converter for the given property.
+     * @param key property reference used as the control identifier
+     */
+    open fun removeConverter(key: KProperty1<K, *>) {
+        form.removeConverter(key)
     }
 
     /**

--- a/kvision/src/jsTest/kotlin/test/io/kvision/form/FormPanelSpec.kt
+++ b/kvision/src/jsTest/kotlin/test/io/kvision/form/FormPanelSpec.kt
@@ -21,6 +21,7 @@
  */
 package test.io.kvision.form
 
+import io.kvision.form.FormFieldConverter
 import io.kvision.form.FormPanel
 import io.kvision.form.check.CheckBox
 import io.kvision.form.form
@@ -164,4 +165,43 @@ class FormPanelSpec : SimpleSpec {
         }
     }
 
+    @Test
+    fun formPanelWithConverter() {
+        run {
+            val formPanel = FormPanel.create<DataFormWithCustom>()
+            val converter = object : FormFieldConverter {
+                override fun fromJson(jsonValue: dynamic): Any? =
+                    (jsonValue as? String)?.uppercase()
+
+                override fun toJson(controlValue: Any?): dynamic =
+                    (controlValue as? String)?.lowercase()
+            }
+            val textField = Text()
+            formPanel.add(DataFormWithCustom::score, textField, converter = converter)
+            formPanel.add(DataFormWithCustom::name, Text())
+            formPanel.setData(DataFormWithCustom(name = "Test", score = "hello"))
+            assertEquals("HELLO", textField.value, "FormPanel converter should transform on setData")
+            val result = formPanel.getData()
+            assertEquals("hello", result.score, "FormPanel converter should reverse-transform on getData")
+            assertEquals("Test", result.name, "Non-converter fields should work normally")
+        }
+    }
+
+    @Test
+    fun formPanelGetDataJsonWithConverter() {
+        run {
+            val formPanel = FormPanel.create<DataFormWithCustom>()
+            val converter = object : FormFieldConverter {
+                override fun fromJson(jsonValue: dynamic): Any? =
+                    (jsonValue as? String)?.uppercase()
+
+                override fun toJson(controlValue: Any?): dynamic =
+                    (controlValue as? String)?.lowercase()
+            }
+            formPanel.add(DataFormWithCustom::score, Text(), converter = converter)
+            formPanel.setData(DataFormWithCustom(score = "HELLO"))
+            val json = formPanel.getDataJson()
+            assertEquals("hello", json["score"], "getDataJson should apply converter")
+        }
+    }
 }

--- a/kvision/src/jsTest/kotlin/test/io/kvision/form/FormSpec.kt
+++ b/kvision/src/jsTest/kotlin/test/io/kvision/form/FormSpec.kt
@@ -23,6 +23,7 @@ package test.io.kvision.form
 
 import kotlinx.serialization.Serializable
 import io.kvision.form.Form
+import io.kvision.form.FormFieldConverter
 import io.kvision.form.check.CheckBox
 import io.kvision.form.text.Text
 import io.kvision.test.SimpleSpec
@@ -42,6 +43,13 @@ data class DataForm(
 data class DataForm2(
     val s: String? = null,
     val d: String? = null
+)
+
+@Serializable
+data class DataFormWithCustom(
+    val name: String? = null,
+    val score: String? = null,
+    val extra: String? = null
 )
 
 class FormSpec : SimpleSpec {
@@ -170,8 +178,191 @@ class FormSpec : SimpleSpec {
             textField.value = "Test value 2"
             check.value = false
             val result3 = form.getData()
-            assertEquals(mapOf("a" to "Test value 2", "b" to false, "c" to 5), result3, "Dynamic form should return changed value")
+            assertEquals(
+                mapOf("a" to "Test value 2", "b" to false, "c" to 5),
+                result3,
+                "Dynamic form should return changed value"
+            )
+        }
+    }
+
+    // --- Converter tests ---
+
+    @Test
+    fun converterAdd() {
+        run {
+            val form = Form.create<DataFormWithCustom>()
+            val converter = object : FormFieldConverter {
+                override fun fromJson(jsonValue: dynamic): Any? {
+                    return (jsonValue as? String)?.uppercase()
+                }
+
+                override fun toJson(controlValue: Any?): dynamic {
+                    return (controlValue as? String)?.lowercase()
+                }
+            }
+            val textField = Text()
+            form.add("score", textField, converter = converter)
+            form.add(DataFormWithCustom::name, Text())
+            form.setData(DataFormWithCustom(name = "Test", score = "hello"))
+            assertEquals("HELLO", textField.value, "Converter should transform value on setData")
+            val result = form.getData()
+            assertEquals("hello", result.score, "Converter should reverse-transform on getData")
+            assertEquals("Test", result.name, "Non-converter fields should work normally")
+        }
+    }
+
+    @Test
+    fun converterOnTypedAdd() {
+        run {
+            val form = Form.create<DataFormWithCustom>()
+            val converter = object : FormFieldConverter {
+                override fun fromJson(jsonValue: dynamic): Any? =
+                    (jsonValue as? String)?.uppercase()
+
+                override fun toJson(controlValue: Any?): dynamic =
+                    (controlValue as? String)?.lowercase()
+            }
+            val textField = Text()
+            // Use typed add() overload with converter parameter
+            form.add(DataFormWithCustom::score, textField, converter = converter)
+            form.setData(DataFormWithCustom(score = "hello"))
+            assertEquals("HELLO", textField.value, "Typed add() with converter should transform on setData")
+            val result = form.getData()
+            assertEquals("hello", result.score, "Typed add() with converter should reverse-transform on getData")
+        }
+    }
+
+    @Test
+    fun registerConverter() {
+        run {
+            val form = Form.create<DataFormWithCustom>()
+            val converter = object : FormFieldConverter {
+                override fun fromJson(jsonValue: dynamic): Any? {
+                    return (jsonValue as? String)?.uppercase()
+                }
+
+                override fun toJson(controlValue: Any?): dynamic {
+                    return (controlValue as? String)?.lowercase()
+                }
+            }
+            val textField = Text()
+            form.add(DataFormWithCustom::score, textField)
+            form.registerConverter(DataFormWithCustom::score, converter)
+            form.setData(DataFormWithCustom(score = "hello"))
+            assertEquals("HELLO", textField.value, "Registered converter should transform value on setData")
+            val result = form.getData()
+            assertEquals("hello", result.score, "Registered converter should reverse-transform on getData")
+        }
+    }
+
+    @Test
+    fun removeConverterFallsBack() {
+        run {
+            val form = Form.create<DataFormWithCustom>()
+            val converter = object : FormFieldConverter {
+                override fun fromJson(jsonValue: dynamic): Any? =
+                    (jsonValue as? String)?.uppercase()
+
+                override fun toJson(controlValue: Any?): dynamic =
+                    (controlValue as? String)?.lowercase()
+            }
+            val textField = Text()
+            form.add(DataFormWithCustom::score, textField, converter = converter)
+            form.setData(DataFormWithCustom(score = "hello"))
+            assertEquals("HELLO", textField.value, "Converter active")
+            // Remove converter
+            form.removeConverter("score")
+            form.setData(DataFormWithCustom(score = "world"))
+            assertEquals("world", textField.value, "After removeConverter, value should pass through unchanged")
+        }
+    }
+
+    // --- Dynamic form + converter test (non-serializer path) ---
+
+    @Test
+    fun dynamicFormWithConverter() {
+        run {
+            val form = Form<Map<String, Any?>>()
+            val converter = object : FormFieldConverter {
+                override fun fromJson(jsonValue: dynamic): Any? =
+                    (jsonValue as? String)?.uppercase()
+
+                override fun toJson(controlValue: Any?): dynamic =
+                    (controlValue as? String)?.lowercase()
+            }
+            val textField = Text()
+            form.add("a", textField, converter = converter)
+            form.setData(mapOf("a" to "hello", "b" to 42))
+            assertEquals("HELLO", textField.value, "Converter should work in non-serializer setData path")
+            val result = form.getData()
+            assertEquals("hello", result["a"], "Converter should work in non-serializer getData path")
+            assertEquals(42, result["b"], "Non-converter fields should pass through")
+        }
+    }
+
+    // --- Overlay tests ---
+
+    @Test
+    fun dataOverlayProvider() {
+        run {
+            val form = Form.create<DataFormWithCustom>()
+            form.add(DataFormWithCustom::name, Text())
+            form.dataOverlayProvider = { mapOf("extra" to "injected") }
+            form.setData(DataFormWithCustom(name = "Test"))
+            val result = form.getData()
+            assertEquals("Test", result.name, "Standard fields should work")
+            assertEquals("injected", result.extra, "Overlay data should be included")
+        }
+    }
+
+    @Test
+    fun overlayOverridesField() {
+        run {
+            val form = Form.create<DataFormWithCustom>()
+            form.add(DataFormWithCustom::name, Text())
+            form.dataOverlayProvider = { mapOf("name" to "overridden") }
+            form.setData(DataFormWithCustom(name = "Original"))
+            val result = form.getData()
+            assertEquals("overridden", result.name, "Overlay should take precedence over field value")
+        }
+    }
+
+    @Test
+    fun dynamicFormWithOverlay() {
+        run {
+            val form = Form<Map<String, Any?>>()
+            form.add("a", Text())
+            form.dataOverlayProvider = { mapOf("b" to "overlaid") }
+            form.setData(mapOf("a" to "hello"))
+            val result = form.getData()
+            assertEquals("hello", result["a"], "Standard field should work")
+            assertEquals("overlaid", result["b"], "Overlay should be included in dynamic form")
+        }
+    }
+
+    @Test
+    fun clearDataPreservesConverter() {
+        run {
+            val form = Form.create<DataFormWithCustom>()
+            val converter = object : FormFieldConverter {
+                override fun fromJson(jsonValue: dynamic): Any? =
+                    (jsonValue as? String)?.uppercase()
+
+                override fun toJson(controlValue: Any?): dynamic =
+                    (controlValue as? String)?.lowercase()
+            }
+            val textField = Text()
+            form.add(DataFormWithCustom::score, textField, converter = converter)
+            form.setData(DataFormWithCustom(score = "hello"))
+            assertEquals("HELLO", textField.value, "Converter active before clearData")
+            form.clearData()
+            assertNull(textField.value, "clearData should null out the field")
+            // Re-set data — converter should still be active
+            form.setData(DataFormWithCustom(score = "world"))
+            assertEquals("WORLD", textField.value, "Converter should survive clearData")
         }
     }
 
 }
+


### PR DESCRIPTION
## Summary

- **`FormFieldConverter`** — per-field converter interface enabling custom type transformations between model values and form control values during `setData()`/`getData()`, beyond the built-in String/Number/Boolean/Date/KFiles handling
- **`dataOverlayProvider`** — optional callback on Form/FormPanel that injects external key-value pairs into `getData()` results, allowing non-FormControl components (tabulators, custom editors) to participate in form data collection

## Problem

KVision's form system handles built-in types during serialization, but custom types require workarounds. Additionally, external components have no way to contribute data to a form without implementing `FormControl`.

## Examples

**FormFieldConverter — mapping an enum ordinal to a select control:**
```kotlin
val converter = object : FormFieldConverter {
    override fun fromJson(jsonValue: dynamic): Any? =
        Priority.entries[jsonValue as Int].name

    override fun toJson(controlValue: Any?): dynamic =
        Priority.valueOf(controlValue as String).ordinal
}
form.add(MyModel::priority, TomSelect(), converter = converter)
```

**FormFieldConverter — via registerConverter():**
```kotlin
form.add(MyModel::score, Text())
form.registerConverter(MyModel::score, myConverter)
// later: form.removeConverter(MyModel::score)
```

**dataOverlayProvider — tabulator contributing row data:**
```kotlin
formPanel.dataOverlayProvider = {
    mapOf("rows" to tabulator.getData().serialize())
}
// overlay values bypass validation and take precedence over field values
```

## Design decisions

- `FormFieldConverter` is a non-generic interface with two methods (`fromJson`/`toJson`) — minimal, easy to implement
- `converter` parameter added to all `add()`/`bind()` overloads (20+) in both `Form` and `FormPanel`, placed before lambda parameters following Kotlin's lambda-last convention. This is fully compatible with named-argument callers; positional callers will see a compile error prompting them to add the new parameter.
- Both features work in serializer (`@Serializable` classes) and non-serializer (`Map`-based) form paths
- Overlay values bypass converter/type dispatch and validation (documented in KDoc). Null overlay values are skipped. Unknown keys cause a deserialization error in serializable forms.
- Converters are cleaned up on `remove()`/`removeAll()` and survive `clearData()`

## Test plan

- [x] Converter via string-key `add()`
- [x] Converter via typed `add()` (KProperty1 overload)
- [x] `registerConverter()` / `removeConverter()` lifecycle
- [x] Converter in non-serializer (Map-based) form path
- [x] Overlay: basic injection, field override, dynamic form
- [x] `clearData()` preserves converter registrations
- [x] FormPanel-level converter delegation
- [x] `getDataJson()` with converter

🤖 Generated with [Claude Code](https://claude.com/claude-code)