### PR TITLE
Fix TabPanel disposal and removeAll behavior

### DIFF
--- a/kvision-modules/kvision-bootstrap/src/jsMain/kotlin/io/kvision/panel/TabPanel.kt
+++ b/kvision-modules/kvision-bootstrap/src/jsMain/kotlin/io/kvision/panel/TabPanel.kt
@@ -334,11 +334,11 @@ open class TabPanel(
     }
 
     override fun removeAll() {
-        tabs.forEach { removeTab(it) }
+        tabs.toList().forEach { removeTab(it) }
     }
 
     override fun disposeAll() {
-        tabs.forEach { it.dispose() }
+        tabs.toList().forEach { it.dispose() }
         removeAll()
     }
 

--- a/kvision-modules/kvision-bootstrap/src/jsMain/kotlin/io/kvision/panel/TabPanel.kt
+++ b/kvision-modules/kvision-bootstrap/src/jsMain/kotlin/io/kvision/panel/TabPanel.kt
@@ -342,6 +342,13 @@ open class TabPanel(
         removeAll()
     }
 
+    override fun dispose() {
+        super.dispose()
+        tabs.toList().forEach { it.dispose() }
+        tabs.forEach { it.clearParent() }
+        tabs.clear()
+    }
+
     /**
      * A helper component for rendering tabs.
      */

--- a/kvision-modules/kvision-bootstrap/src/jsTest/kotlin/test/io/kvision/panel/TabPanelSpec.kt
+++ b/kvision-modules/kvision-bootstrap/src/jsTest/kotlin/test/io/kvision/panel/TabPanelSpec.kt
@@ -31,9 +31,12 @@ import io.kvision.panel.Root
 import io.kvision.panel.Tab
 import io.kvision.panel.TabPanel
 import io.kvision.panel.tab
+import io.kvision.panel.vPanel
 import io.kvision.test.DomSpec
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 class TabPanelSpec : DomSpec {
 
@@ -178,6 +181,71 @@ class TabPanelSpec : DomSpec {
                 element?.innerHTML,
                 "Should remove tab"
             )
+        }
+    }
+
+    @Test
+    fun dispose() {
+        run {
+            lateinit var tab: Tab
+            var hookFired = 0
+            val tabs = TabPanel {
+                tab = tab("One") {
+                    addBeforeDisposeHook {
+                        hookFired++
+                        assertNotNull(tab.parent, "Should dispose the tab before detaching it")
+                    }
+                }
+            }
+            tabs.dispose()
+            assertEquals(1, hookFired, "Should dispose every tab")
+            assertEquals(0, tabs.getSize(), "Should remove every disposed tab")
+            assertNull(tab.parent, "Should detach every disposed tab")
+        }
+    }
+
+    @Test
+    fun disposeWithoutChangeTabEvents() {
+        run {
+            val root = Root("test", containerType = io.kvision.panel.ContainerType.FIXED)
+            val tabs = TabPanel {
+                tab("ABC") {
+                    span("abc")
+                }
+                tab("DEF") {
+                    span("def")
+                }
+            }
+            root.add(tabs)
+            val element = assertNotNull(tabs.getElement(), "Should render the tab panel")
+            var changeTabEvents = 0
+            element.addEventListener("changeTab", { changeTabEvents++ })
+            tabs.dispose()
+            assertEquals(0, changeTabEvents, "Should not dispatch changeTab events while disposing")
+        }
+    }
+
+    @Test
+    fun disposeTabContent() {
+        run {
+            var activeHooks = 0
+            var inactiveHooks = 0
+            val tabs = TabPanel {
+                tab("Active") {
+                    vPanel {
+                        addBeforeDisposeHook { activeHooks++ }
+                    }
+                }
+                tab("Inactive") {
+                    vPanel {
+                        addBeforeDisposeHook { inactiveHooks++ }
+                    }
+                }
+            }
+            tabs.dispose()
+            tabs.dispose()
+            assertEquals(1, activeHooks, "Should dispose the content of the active tab exactly once")
+            assertEquals(1, inactiveHooks, "Should dispose the content of the inactive tab exactly once")
         }
     }
 

--- a/kvision-modules/kvision-bootstrap/src/jsTest/kotlin/test/io/kvision/panel/TabPanelSpec.kt
+++ b/kvision-modules/kvision-bootstrap/src/jsTest/kotlin/test/io/kvision/panel/TabPanelSpec.kt
@@ -185,6 +185,23 @@ class TabPanelSpec : DomSpec {
     }
 
     @Test
+    fun removeAll() {
+        run {
+            val tabs = TabPanel {
+                repeat(4) {
+                    tab("Tab $it") {}
+                }
+            }
+            val originalTabs = tabs.getTabs().toList()
+            tabs.removeAll()
+            assertEquals(0, tabs.getSize(), "Should remove all tabs")
+            originalTabs.forEach {
+                assertNull(it.parent, "Should detach every removed tab")
+            }
+        }
+    }
+
+    @Test
     fun dispose() {
         run {
             lateinit var tab: Tab
@@ -246,6 +263,23 @@ class TabPanelSpec : DomSpec {
             tabs.dispose()
             assertEquals(1, activeHooks, "Should dispose the content of the active tab exactly once")
             assertEquals(1, inactiveHooks, "Should dispose the content of the inactive tab exactly once")
+        }
+    }
+
+    @Test
+    fun disposeAll() {
+        run {
+            var hooksFired = 0
+            val tabs = TabPanel {
+                repeat(4) {
+                    tab("Tab $it") {
+                        addBeforeDisposeHook { hooksFired++ }
+                    }
+                }
+            }
+            tabs.disposeAll()
+            assertEquals(4, hooksFired, "Should dispose every tab")
+            assertEquals(0, tabs.getSize(), "Should remove every disposed tab")
         }
     }
 


### PR DESCRIPTION
Two independent defects in `TabPanel` (kvision-bootstrap), one commit each. Both are present in every release since 2020 and in current `master` (91758bda5c0).

## 1. `TabPanel.dispose()` never disposes its tabs

`TabPanel` keeps its tabs in its own `tabs` list. `addTab` sets `tab.parent = nav` and appends to that list; tabs never enter `children` or `privateChildren`. The class overrides `disposeAll()` but not `dispose()`, and `SimplePanel.dispose()` only walks `children` and `privateChildren`. So disposing a `TabPanel` directly, or transitively from any ancestor, never reaches `Tab.dispose()`.

Consequences:

- `addBeforeDisposeHook` hooks registered anywhere inside a tab never run: subscriptions, timers and periodic refreshers registered in tab content keep running after the panel is gone. Both the active and the inactive tabs are affected, since `TabPanelContent` renders the active tab by reading the `tabs` list directly.
- `Tab.dispose()` is also where a routed tab unregisters its router handler (`kvOff`). When a panel with routed tabs is disposed through `dispose()` while the application keeps running (a modal closing, a view being replaced), that handler stays registered and later sets `activeTab` on a disposed panel.
- The framework itself disposes through this path: `Application` calls `Root.disposeAllRoots()` on hot reload, which cascades through `SimplePanel.dispose()`, so tab dispose hooks are skipped there as well.

History: the `disposeAll()` override and the child-cascading `SimplePanel.dispose()` were introduced in the same commit, f8d7202d7eb (Dec 2020). `TabPanel.dispose()` has never cascaded to the tabs since.

Minimal reproduction:

```kotlin
var hookFired = 0
val panel = TabPanel {
    tab("One") {
        vPanel { addBeforeDisposeHook { hookFired++ } }
    }
}
panel.dispose()
// hookFired == 0, expected 1
```

## 2. `removeAll()` skips every other tab

```kotlin
override fun removeAll() {
    tabs.forEach { removeTab(it) }
}
```

`removeTab` removes from the same list being iterated. The Kotlin/JS `AbstractMutableList` iterator is index based and does not check for concurrent modification, so the loop silently skips every other element instead of throwing. With four tabs, two survive `removeAll()` with `parent` still set. `disposeAll()` inherits this: it disposes every tab, then delegates to `removeAll()` and leaves every other disposed tab registered.

```kotlin
val panel = TabPanel { repeat(4) { tab("Tab $it") {} } }
panel.removeAll()
// panel.getTabs().size == 2, expected 0
```

## Fix

```kotlin
override fun removeAll() {
    tabs.toList().forEach { removeTab(it) }
}

override fun disposeAll() {
    tabs.toList().forEach { it.dispose() }
    removeAll()
}

override fun dispose() {
    super.dispose()
    tabs.toList().forEach { it.dispose() }
    tabs.forEach { it.clearParent() }
    tabs.clear()
}
```

`dispose()` follows the idiom the repository already uses for component collections held outside `children`, see `SimplePanel.dispose()` and `MdWidget.dispose()` (kvision-material): tabs are disposed while still attached (hooks see the same parent chain that regular children see), then detached, then the list is cleared, which also makes a second `dispose()` a no-op for the tabs.

It deliberately does not go through `removeTab`, even though that would also reset `activeIndex`. `removeTab` assigns `activeIndex` on every branch, and the setter re-toggles the `active` class on every remaining tab link and dispatches a `changeTab` event, so disposing through it would run selection updates for each tab and emit a sequence of `changeTab` events ending at `-1`. A consumer that persists the active tab on `changeTab` would record `-1` while the panel is being destroyed. Clearing the parent and the list directly avoids selection updates and change events during disposal; `activeIndex` is left as is, and `activeTab` returns `null` on the empty list. A test asserts that no `changeTab` event is dispatched while disposing a rendered panel.

`disposeAll()` also iterates a snapshot, since dispose hooks may in principle mutate the list. No public API changes.

## Tests

Added to `TabPanelSpec`:

- `dispose`: hook fires exactly once, hook observes the tab still attached, tab list empty and tab detached afterwards.
- `disposeTabContent`: a hook in the content of the active tab and one in the inactive tab each fire exactly once, and a second `dispose()` does not fire them again.
- `disposeWithoutChangeTabEvents`: disposing a rendered panel dispatches no `changeTab` event.
- `removeAll`: four tabs, list empty and every tab detached.
- `disposeAll`: four hooks fire and the list is empty.

`dispose`, `disposeTabContent`, `removeAll` and `disposeAll` fail on unfixed `master` and pass with the fixes. The full kvision-bootstrap JS test suite is green.

## How it was found

By measuring network calls in a production application, not by reading the code. A view opened in a modal ran four periodic refreshers on an exact 5 s cadence. On closing the modal, the three that lived outside a tab were cancelled, but a list embedded inside a tab kept requesting data (still going 40 s later), and every re-activation of that tab added one more request per cycle. With the fix, the same sequence returns to baseline immediately on close and stays there after three open / activate tab / close cycles.


## References (master at 91758bda5c0)

- https://github.com/rjaros/kvision/blob/91758bda5c0/kvision-modules/kvision-bootstrap/src/jsMain/kotlin/io/kvision/panel/TabPanel.kt#L82
- https://github.com/rjaros/kvision/blob/91758bda5c0/kvision-modules/kvision-bootstrap/src/jsMain/kotlin/io/kvision/panel/TabPanel.kt#L221-L227
- https://github.com/rjaros/kvision/blob/91758bda5c0/kvision-modules/kvision-bootstrap/src/jsMain/kotlin/io/kvision/panel/TabPanel.kt#L263-L274
- https://github.com/rjaros/kvision/blob/91758bda5c0/kvision-modules/kvision-bootstrap/src/jsMain/kotlin/io/kvision/panel/TabPanel.kt#L336-L343
- https://github.com/rjaros/kvision/blob/91758bda5c0/kvision-modules/kvision-bootstrap/src/jsMain/kotlin/io/kvision/panel/Tab.kt#L165-L168
- https://github.com/rjaros/kvision/blob/91758bda5c0/kvision/src/jsMain/kotlin/io/kvision/panel/SimplePanel.kt#L180-L190
- https://github.com/rjaros/kvision/commit/f8d7202d7eb

---

Out of scope: `MdListWidget` in kvision-material (`MdTabs`, `MdChipSet`) keeps its items outside `children` in the same way and shows the same gap in a quick probe (`dispose()` skips the items, `disposeAll()` reaches them). Happy to send a separate PR for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
